### PR TITLE
Add recovery mode

### DIFF
--- a/cmd/dogeboxd/main.go
+++ b/cmd/dogeboxd/main.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"flag"
+	"log"
 	"os"
 
 	dogeboxd "github.com/dogeorg/dogeboxd/pkg"
+	"github.com/dogeorg/dogeboxd/pkg/system"
 )
 
 func main() {
@@ -16,11 +18,13 @@ func main() {
 	var nixDir string
 	var verbose bool
 	var help bool
+	var forcedRecovery bool
 
 	flag.IntVar(&port, "port", 8080, "REST API Port")
 	flag.StringVar(&bind, "addr", "127.0.0.1", "Address to bind to")
 	flag.StringVar(&pupDir, "pups", "./pups", "Directory to find local pups")
 	flag.StringVar(&nixDir, "nix", "./nix", "Directory to find nix ??")
+	flag.BoolVar(&forcedRecovery, "force-recovery", false, "Force recovery mode")
 	flag.BoolVar(&verbose, "v", false, "Be verbose")
 	flag.BoolVar(&help, "h", false, "Get help")
 	flag.Parse()
@@ -30,12 +34,24 @@ func main() {
 		os.Exit(0)
 	}
 
+	recoveryMode := system.ShouldEnterRecovery()
+	if forcedRecovery {
+		recoveryMode = true
+	}
+
+	if recoveryMode {
+		log.Println("********************************************************************************")
+		log.Println("************************ ENTERING DOGEBOX RECOVERY MODE ************************")
+		log.Println("********************************************************************************")
+	}
+
 	config := dogeboxd.ServerConfig{
-		Port:    port,
-		Bind:    bind,
-		PupDir:  pupDir,
-		NixDir:  nixDir,
-		Verbose: verbose,
+		Port:     port,
+		Bind:     bind,
+		PupDir:   pupDir,
+		NixDir:   nixDir,
+		Verbose:  verbose,
+		Recovery: recoveryMode,
 	}
 
 	srv := Server(config)

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -1,9 +1,10 @@
 package dogeboxd
 
 type ServerConfig struct {
-	PupDir  string
-	NixDir  string
-	Bind    string
-	Port    int
-	Verbose bool
+	PupDir   string
+	NixDir   string
+	Bind     string
+	Port     int
+	Verbose  bool
+	Recovery bool
 }

--- a/pkg/dogeboxd.go
+++ b/pkg/dogeboxd.go
@@ -81,12 +81,7 @@ type Dogeboxd struct {
 	Changes        chan Change
 }
 
-func NewDogeboxd(pupDir string, man ManifestIndex, updater SystemUpdater, monitor SystemMonitor, journal JournalReader, networkManager NetworkManager, lifecycle LifecycleManager) Dogeboxd {
-	intern := InternalState{
-		ActionCounter: 100000,
-		InstalledPups: []string{"internal.dogeboxd"},
-	}
-	// TODO: Load state from GOB
+func NewDogeboxd(internalState InternalState, pupDir string, man ManifestIndex, updater SystemUpdater, monitor SystemMonitor, journal JournalReader, networkManager NetworkManager, lifecycle LifecycleManager) Dogeboxd {
 	s := Dogeboxd{
 		Manifests:      man,
 		Pups:           map[string]PupStatus{},
@@ -97,7 +92,7 @@ func NewDogeboxd(pupDir string, man ManifestIndex, updater SystemUpdater, monito
 		lifecycle:      lifecycle,
 		jobs:           make(chan Job),
 		Changes:        make(chan Change),
-		Internal:       &intern,
+		Internal:       &internalState,
 	}
 
 	// TODO start monitoring all installed services

--- a/pkg/system/recovery.go
+++ b/pkg/system/recovery.go
@@ -1,0 +1,61 @@
+package system
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var VALID_RECOVERY_FILES = []string{"RECOVERY", "RECOVERY.TXT"}
+
+// This function should do detection on whether or not we should enter our "Recovery Mode".
+// This can always be overriden by a CLI flag if necessary.
+func ShouldEnterRecovery() bool {
+	return hasRecoveryTXT()
+}
+
+func hasRecoveryTXT() bool {
+	file, err := os.Open("/proc/mounts")
+	if err != nil {
+		fmt.Printf("Error opening /proc/mounts: %v\n", err)
+		return false
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Fields(line)
+
+		// Ensure the line has enough fields (device, mount point, etc.)
+		if len(fields) < 2 {
+			continue
+		}
+
+		device := fields[0]
+		mountPoint := fields[1]
+
+		// Check if the device name starts with /dev/sd (which is typical for USB devices)
+		if strings.HasPrefix(device, "/dev/sd") {
+			fmt.Printf("USB device %s is mounted at %s\n", device, mountPoint)
+
+			// Check for valid recovery files at the mount point
+			for _, validFile := range VALID_RECOVERY_FILES {
+				filePath := filepath.Join(mountPoint, validFile)
+				if _, err := os.Stat(filePath); err == nil {
+					fmt.Printf("Found recovery file: %s\n", filePath)
+					return true
+				}
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Printf("Error reading /proc/mounts: %v\n", err)
+	}
+
+	return false
+}

--- a/pkg/websocket.go
+++ b/pkg/websocket.go
@@ -3,6 +3,7 @@ package dogeboxd
 import (
 	"context"
 	"fmt"
+	"log"
 	"sync"
 
 	"golang.org/x/net/websocket"
@@ -11,16 +12,23 @@ import (
 const WS_DEFAULT_CHANNEL string = "updates"
 
 type WSRelay struct {
-	socks []WSCONN
-	relay chan Change
-	newWs chan WSCONN
+	config ServerConfig
+	socks  []WSCONN
+	relay  chan Change
+	newWs  chan WSCONN
 }
 
-func NewWSRelay(relay chan Change) WSRelay {
+func NewWSRelay(config ServerConfig, relay chan Change) WSRelay {
+	if config.Recovery {
+		log.Printf("In recovery mode: not initialising WSRelay")
+		return WSRelay{}
+	}
+
 	return WSRelay{
-		socks: []WSCONN{},
-		relay: relay,
-		newWs: make(chan WSCONN),
+		config: config,
+		socks:  []WSCONN{},
+		relay:  relay,
+		newWs:  make(chan WSCONN),
 	}
 }
 


### PR DESCRIPTION
This adds recovery mode to dogeboxd. This currently limits functionality served by dogeboxd, and will serve a different entrypoint into dpanel once we add that.

Recovery mode is activated by either passing in a `--force-recovery` flag to the `dogeboxd` binary, or by having a file named `RECOVERY` or `RECOVERY.TXT` on a mounted `/dev/sd*` device.

Normal: 

```
adam@doge:/dogeboxd$ ./build/dogeboxd -v
==== hydrated local.Core
2024/08/19 16:51:44 No existing state file found. Starting with empty state.
Loading pup status: internal.dogeboxd
2024/08/19 16:51:44 Loaded 10 API routes
🔧 Starting 'Dogeboxd':
.. ok
🔧 Starting 'REST API':
.. ok
🔧 Starting 'System Updater':
.. ok
🔧 Starting 'System Monitor':
.. ok
🔧 Starting 'WSock Relay':
.. ok

```

Recovery:

```
adam@doge:/dogeboxd$ ./build/dogeboxd --force-recovery
2024/08/19 16:52:20 ********************************************************************************
2024/08/19 16:52:20 ************************ ENTERING DOGEBOX RECOVERY MODE ************************
2024/08/19 16:52:20 ********************************************************************************
2024/08/19 16:52:20 In recovery mode: not loading manifests.
2024/08/19 16:52:20 In recovery mode: not loading state.
2024/08/19 16:52:20 In recovery mode: not initialising WSRelay
2024/08/19 16:52:20 In recovery mode: Loading limited routes
🔧 Starting 'Dogeboxd':
.. ok
🔧 Starting 'REST API':
.. ok
```