### PR TITLE
Serve frontend UI

### DIFF
--- a/cmd/dogeboxd/main.go
+++ b/cmd/dogeboxd/main.go
@@ -16,6 +16,8 @@ func main() {
 	var bind string
 	var pupDir string
 	var nixDir string
+	var uiDir string
+	var uiPort int
 	var verbose bool
 	var help bool
 	var forcedRecovery bool
@@ -24,6 +26,8 @@ func main() {
 	flag.StringVar(&bind, "addr", "127.0.0.1", "Address to bind to")
 	flag.StringVar(&pupDir, "pups", "./pups", "Directory to find local pups")
 	flag.StringVar(&nixDir, "nix", "./nix", "Directory to find nix ??")
+	flag.StringVar(&uiDir, "uidir", "../dpanel/src", "Directory to find admin UI (dpanel)")
+	flag.IntVar(&uiPort, "uiport", 8081, "Port for serving admin UI (dpanel)")
 	flag.BoolVar(&forcedRecovery, "force-recovery", false, "Force recovery mode")
 	flag.BoolVar(&verbose, "v", false, "Be verbose")
 	flag.BoolVar(&help, "h", false, "Get help")
@@ -52,6 +56,8 @@ func main() {
 		NixDir:   nixDir,
 		Verbose:  verbose,
 		Recovery: recoveryMode,
+		UiDir:    uiDir,
+		UiPort:   uiPort,
 	}
 
 	srv := Server(config)

--- a/cmd/dogeboxd/server.go
+++ b/cmd/dogeboxd/server.go
@@ -98,6 +98,8 @@ func (t server) Start() {
 	wsh := dogeboxd.NewWSRelay(t.config, dbx.Changes)
 	rest := dogeboxd.RESTAPI(t.config, dbx, wsh)
 
+	dogeboxd.ServeUI(t.config)
+
 	/* ----------------------------------------------------------------------- */
 	// Create a conductor to manage all the above services startup/shutdown
 

--- a/cmd/dogeboxd/server.go
+++ b/cmd/dogeboxd/server.go
@@ -97,8 +97,7 @@ func (t server) Start() {
 
 	wsh := dogeboxd.NewWSRelay(t.config, dbx.Changes)
 	rest := dogeboxd.RESTAPI(t.config, dbx, wsh)
-
-	dogeboxd.ServeUI(t.config)
+	ui := dogeboxd.ServeUI(t.config)
 
 	/* ----------------------------------------------------------------------- */
 	// Create a conductor to manage all the above services startup/shutdown
@@ -117,6 +116,7 @@ func (t server) Start() {
 	}
 	c.Service("Dogeboxd", dbx)
 	c.Service("REST API", rest)
+	c.Service("UI Server", ui)
 
 	if !t.config.Recovery {
 		c.Service("System Updater", systemUpdater)

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -7,4 +7,6 @@ type ServerConfig struct {
 	Port     int
 	Verbose  bool
 	Recovery bool
+	UiDir    string
+	UiPort   int
 }

--- a/pkg/ui.go
+++ b/pkg/ui.go
@@ -1,0 +1,59 @@
+package dogeboxd
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"path/filepath"
+)
+
+func serveSPA(directory string, mainIndex string) http.HandlerFunc {
+	mainIndexPath := filepath.Join(directory, mainIndex)
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Disable caching
+		w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
+		w.Header().Set("Pragma", "no-cache")
+		w.Header().Set("Expires", "0")
+
+		if r.URL.Path == "/" {
+			http.ServeFile(w, r, mainIndexPath)
+			return
+		}
+
+		filePath := filepath.Join(directory, r.URL.Path)
+
+		files, err := filepath.Glob(filePath)
+		if err != nil {
+			log.Println("Error searching for UI file:", err)
+			http.ServeFile(w, r, mainIndexPath)
+			return
+		}
+
+		// Can't find the requested file, serve index.
+		if len(files) == 0 {
+			http.ServeFile(w, r, mainIndexPath)
+			return
+		}
+
+		// Otherwise, serve the requested file
+		http.ServeFile(w, r, filePath)
+	}
+}
+
+func ServeUI(config ServerConfig) {
+	entryPoint := "index.html"
+
+	if config.Recovery {
+		entryPoint = "index_recovery.html"
+		log.Println("In recovery mode: Serving recovery UI")
+	} else {
+		log.Println("Serving normal UI")
+	}
+
+	http.HandleFunc("/", serveSPA(config.UiDir, entryPoint))
+
+	if err := http.ListenAndServe(fmt.Sprintf("%s:%d", config.Bind, config.UiPort), nil); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
As a temporary measure, we will serve dpanel through dogeboxd directly (rather than putting it in its own pup).

This currently assumes (by default) you have `dpanel` cloned into the parent directory of `dogeboxd`.

This will serve `index.html` in normal mode, and `index_recovery.html` in dogebox recovery mode.