### PR TITLE
Change network to 10.69.0.0/16 + small nixfile fix

### DIFF
--- a/pkg/pup_manager.go
+++ b/pkg/pup_manager.go
@@ -77,7 +77,7 @@ func NewPupManager(dataDir string, tmpDir string, monitor SystemMonitor) (PupMan
 	}
 
 	// set lastIP for IP Generation
-	ip := net.IP{10, 0, 0, 1} // skip 0.1 (dogeboxd)
+	ip := net.IP{10, 69, 0, 1} // skip 0.1 (dogeboxd)
 	for _, v := range p.state {
 		ip2 := net.ParseIP(v.IP).To4()
 		for i := 0; i < 4; i++ {
@@ -131,8 +131,8 @@ func (t PupManager) AdoptPup(m pup.PupManifest, source ManifestSource) (string, 
 	}
 
 	// Check if we have gone off the edge of the world
-	if t.lastIP[0] > 10 || (t.lastIP[0] == 10 && t.lastIP[1] > 0) {
-		return PupID, errors.New("exhausted 65,536 IP addresses, what are you doing??")
+	if t.lastIP[0] > 10 || (t.lastIP[0] == 10 && t.lastIP[1] > 70) {
+		return PupID, errors.New("exhausted 65,534 IP addresses, what are you doing??")
 	}
 
 	// Set up initial PupState and save it to disk

--- a/pkg/system/nix/nix.go
+++ b/pkg/system/nix/nix.go
@@ -50,8 +50,8 @@ func (nm nixManager) InitSystem(pups dogeboxd.PupManager) error {
 
 	// TODO: set these values properly
 	sshEnabled := false
-	hostIp := "10.0.0.1"
-	containerCidr := "10.0.0.0/8"
+	hostIp := "10.69.0.1"
+	containerCidr := "10.69.0.0/8"
 	sshKeys := []string{}
 	systemHostname := "dogebox"
 

--- a/pkg/system/nix/templates/pup_container.nix
+++ b/pkg/system/nix/templates/pup_container.nix
@@ -15,10 +15,10 @@ in
     autoStart = {{.PUP_ENABLED}};
 
     # Set up private networking. This will ensure the pup gets an internal IP
-    # in the range of 10.0.0.0/8, be able to to dogeboxd at 10.0.0.1, but not
+    # in the range of 10.69.0.0/8, be able to to dogeboxd at 10.69.0.1, but not
     # be able to talk to any other pups without proxying through dogeboxd.
     privateNetwork = true;
-    hostAddress = "10.0.0.1";
+    hostAddress = "10.69.0.1";
     localAddress = "{{.INTERNAL_IP}}";
 
     # Mount somewhere that can be used as storage for the pup.
@@ -61,7 +61,7 @@ in
         };
         hosts = {
           # Helper so you can always hit dogebox(d) in DNS.
-          "10.0.0.1" = [ "dogeboxd" "dogeboxd.local" "dogebox" "dogebox.local" ];
+          "10.69.0.1" = [ "dogeboxd" "dogeboxd.local" "dogebox" "dogebox.local" ];
         };
       };
 

--- a/pkg/system/nix/templates/system.nix
+++ b/pkg/system/nix/templates/system.nix
@@ -23,6 +23,8 @@
   services.openssh.enable = {{ .SSH_ENABLED }};
 
   users.users.shibe = {
+    isNormalUser = true;
+    group = "wheel";
     openssh = {
       authorizedKeys = {
         keys = [


### PR DESCRIPTION
- This changes the internal container network to `10.69.0.0/16` to avoid conflicting with home-networks that might be using `10.0.0.0/8` already.

- Fixes our nix files missing a couple of attributes needed for our shibe user. This isn't an issue in our release builds as we provide these in the pre-baked "system" configuration, but developers running dogeboxd in their own environments will likely not have these changes.