### PR TITLE
Allow pups to listen on host ports

### DIFF
--- a/cmd/dogeboxd/server.go
+++ b/cmd/dogeboxd/server.go
@@ -39,7 +39,7 @@ func (t server) Start() {
 	}
 
 	sourceManager := source.NewSourceManager(t.config, t.sm, pups)
-	nixManager := nix.NewNixManager(t.config)
+	nixManager := nix.NewNixManager(t.config, pups)
 
 	// Set up our system interfaces so we can talk to the host OS
 	networkManager := network.NewNetworkManager(nixManager, t.sm)

--- a/pkg/pup/manifest.go
+++ b/pkg/pup/manifest.go
@@ -116,10 +116,11 @@ type PupManifestCommand struct {
 
 /* Allow the user to expose certain ports in their container. */
 type PupManifestExposeConfig struct {
-	Type        string   `json:"type"`        // Freeform field, but we'll handle certain cases of "admin" or "public", "api"
-	TrafficType string   `json:"trafficType"` // HTTP, Raw TCP etc. Used by the frontend in addition to type to understand if something can be iframed.
-	Port        int      `json:"port"`        // The port that is being listened on inside the container.
-	Interfaces  []string `json:"interfaces"`  // Designates that certain interfaces can be accessed on this port
+	Type         string   `json:"type"`         // Freeform field, but we'll handle certain cases of "admin" or "public", "api"
+	TrafficType  string   `json:"trafficType"`  // HTTP, Raw TCP etc. Used by the frontend in addition to type to understand if something can be iframed.
+	Port         int      `json:"port"`         // The port that is being listened on inside the container.
+	Interfaces   []string `json:"interfaces"`   // Designates that certain interfaces can be accessed on this port
+	ListenOnHost bool     `json:"listenOnHost"` // If true, the port will be accessible on the host network, otherwise it will listen on a private internal network interface.
 }
 
 type PupManifestInterface struct {

--- a/pkg/sys.go
+++ b/pkg/sys.go
@@ -198,10 +198,13 @@ type NixPupContainerServiceValues struct {
 }
 
 type NixPupContainerTemplateValues struct {
-	PUP_ID       string
-	PUP_ENABLED  bool
-	INTERNAL_IP  string
-	PUP_PORTS    []int
+	PUP_ID      string
+	PUP_ENABLED bool
+	INTERNAL_IP string
+	PUP_PORTS   []struct {
+		PORT   int
+		PUBLIC bool
+	}
 	STORAGE_PATH string
 	PUP_PATH     string
 	NIX_FILE     string
@@ -216,6 +219,11 @@ type NixSystemContainerConfigTemplateValues struct {
 
 type NixFirewallTemplateValues struct {
 	SSH_ENABLED bool
+	PUP_PORTS   []struct {
+		PORT   int
+		PUBLIC bool
+		PUP_ID string
+	}
 }
 
 type NixSystemTemplateValues struct {
@@ -239,7 +247,7 @@ type NixNetworkTemplateValues struct {
 type NixManager interface {
 	Rebuild() error
 	RebuildBoot() error
-	InitSystem(pups PupManager) error
+	InitSystem() error
 	UpdateIncludeFile(pups PupManager) error
 	WriteDogeboxNixFile(filename string, content string) error
 	WritePupFile(pupState PupState) error

--- a/pkg/system/nix/templates/firewall.nix
+++ b/pkg/system/nix/templates/firewall.nix
@@ -4,6 +4,14 @@
   networking.firewall.enable = true;
 
   networking.firewall.allowedTCPPorts = [
-    {{ if .SSH_ENABLED }} 22 {{end}}
+    {{ if .SSH_ENABLED }}
+    # TODO: Allow the user to customise this at some point.
+    # Enable port 22 for OpenSSH
+    22
+    {{end}}
+    {{ range .PUP_PORTS }}{{ if .PUBLIC }}
+    # Open port {{.PORT}} (forwarding to {{.PORT}}) for pup {{.PUP_ID}}
+    {{.PORT}}
+    {{end}}{{end}}
   ];
 }

--- a/pkg/system/nix/templates/pup_container.nix
+++ b/pkg/system/nix/templates/pup_container.nix
@@ -21,6 +21,14 @@ in
     hostAddress = "10.69.0.1";
     localAddress = "{{.INTERNAL_IP}}";
 
+    forwardPorts = [
+      {{ range .PUP_PORTS }}{{ if .PUBLIC }}{
+        containerPort = {{ .PORT }};
+        hostPort = {{ .PORT }};
+        protocol = "tcp";
+      }{{end}}{{end}}
+    ];
+
     # Mount somewhere that can be used as storage for the pup.
     # The rest of the filesystem is marked as readonly (and ephemeral)
     bindMounts = {
@@ -57,7 +65,7 @@ in
           enable = true;
           # If the pup has marked that is listens on ports
           # explicitly whitelist those in the container fw.
-          allowedTCPPorts = [ {{ range .PUP_PORTS }}{{ . }} {{end}}];
+          allowedTCPPorts = [ {{ range .PUP_PORTS }}{{ .PORT }} {{end}}];
         };
         hosts = {
           # Helper so you can always hit dogebox(d) in DNS.

--- a/pkg/web/setup.go
+++ b/pkg/web/setup.go
@@ -93,7 +93,7 @@ func (t api) initialBootstrap(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := t.nix.InitSystem(t.dbx.Pups); err != nil {
+	if err := t.nix.InitSystem(); err != nil {
 		sendErrorResponse(w, http.StatusInternalServerError, "Error initialising system")
 		return
 	}


### PR DESCRIPTION
This lets client pups listen on host ports, allowing the user to port-forward on their router and expose things to the internet.

This is required for running proper P2P nodes etc.

This adds a `ListenOnHost` to the manifest, under the exposes section. We have discussed changing this going forward, but this is the easiest go for now.