### PR TITLE
Allow pups to request access to the internet

### DIFF
--- a/pkg/pup/manifest.go
+++ b/pkg/pup/manifest.go
@@ -85,6 +85,8 @@ type PupManifestContainer struct {
 	// as an artifact here with the correct execution configuration.
 	Services []PupManifestService      `json:"services"`
 	Exposes  []PupManifestExposeConfig `json:"exposes"`
+	// This pup requires internet access to function.
+	RequiresInternet bool `json:"requiresInternet"`
 }
 
 /* PupManifestBuild holds information about the target nix

--- a/pkg/sys.go
+++ b/pkg/sys.go
@@ -211,10 +211,15 @@ type NixPupContainerTemplateValues struct {
 	SERVICES     []NixPupContainerServiceValues
 }
 
+type NixSystemContainerConfigTemplatePupRequiresInternet struct {
+	PUP_ID string
+	PUP_IP string
+}
+
 type NixSystemContainerConfigTemplateValues struct {
-	// NETWORK_INTERFACE      string
-	DOGEBOX_HOST_IP        string
-	DOGEBOX_CONTAINER_CIDR string
+	DOGEBOX_HOST_IP         string
+	DOGEBOX_CONTAINER_CIDR  string
+	PUPS_REQUIRING_INTERNET []NixSystemContainerConfigTemplatePupRequiresInternet
 }
 
 type NixFirewallTemplateValues struct {
@@ -253,6 +258,6 @@ type NixManager interface {
 	WritePupFile(pupState PupState) error
 	RemovePupFile(pupId string) error
 	UpdateSystem(values NixSystemTemplateValues) error
-	UpdateSystemContainerConfiguration(values NixSystemContainerConfigTemplateValues) error
+	UpdateSystemContainerConfiguration() error
 	UpdateNetwork(values NixNetworkTemplateValues) error
 }


### PR DESCRIPTION
Adds a new manifest field `.container.requiresInternet` that whitelists the pup to allow traffic outbound to the internet.

This still blocks traffic inbound, and still blocks talking directly to other pups on `10.69.0.0/16` 