### PR TITLE
Inter-pup TCP comms

### DIFF
--- a/cmd/dogeboxd/server.go
+++ b/cmd/dogeboxd/server.go
@@ -60,7 +60,7 @@ func (t server) Start() {
 	/* ----------------------------------------------------------------------- */
 	// Set up Dogeboxd, the beating heart of the beast
 
-	dbx := dogeboxd.NewDogeboxd(t.sm, pups, systemUpdater, systemMonitor, journalReader, networkManager, sourceManager)
+	dbx := dogeboxd.NewDogeboxd(t.sm, pups, systemUpdater, systemMonitor, journalReader, networkManager, sourceManager, nixManager)
 
 	/* ----------------------------------------------------------------------- */
 	// Setup our external APIs. REST, Websockets

--- a/pkg/dogeboxd.go
+++ b/pkg/dogeboxd.go
@@ -53,6 +53,7 @@ type Dogeboxd struct {
 	NetworkManager NetworkManager
 	sm             StateManager
 	sources        SourceManager
+	nix            NixManager
 	jobs           chan Job
 	Changes        chan Change
 }
@@ -65,6 +66,7 @@ func NewDogeboxd(
 	journal JournalReader,
 	networkManager NetworkManager,
 	sourceManager SourceManager,
+	nixManager NixManager,
 ) Dogeboxd {
 	s := Dogeboxd{
 		Pups:           pups,
@@ -74,6 +76,7 @@ func NewDogeboxd(
 		NetworkManager: networkManager,
 		sm:             stateManager,
 		sources:        sourceManager,
+		nix:            nixManager,
 		jobs:           make(chan Job),
 		Changes:        make(chan Change),
 	}
@@ -276,6 +279,23 @@ func (t *Dogeboxd) updatePupProviders(j Job, u UpdatePupProviders) {
 		t.sendFinishedJob("action", j)
 		return
 	}
+
+	// Once we've updated our providers, we might need to rebuild
+	// some of our container configurations to fix up firewall rules.
+	if err := t.nix.UpdateSystemContainerConfiguration(); err != nil {
+		fmt.Println("Failed to update container configuration:", err)
+		j.Err = err.Error()
+		t.sendFinishedJob("action", j)
+		return
+	}
+
+	if err := t.nix.Rebuild(); err != nil {
+		fmt.Println("Failed to rebuild:", err)
+		j.Err = err.Error()
+		t.sendFinishedJob("action", j)
+		return
+	}
+
 	t.sendFinishedJob("action", j)
 }
 

--- a/pkg/pup/manifest.go
+++ b/pkg/pup/manifest.go
@@ -53,6 +53,20 @@ func (m *PupManifest) Validate() error {
 		}
 	}
 
+	for _, expose := range m.Container.Exposes {
+		if expose.Name == "" {
+			return fmt.Errorf("expose name is required")
+		}
+
+		if expose.Port <= 0 || expose.Port > 65535 {
+			return fmt.Errorf("expose port must be between 1 and 65535")
+		}
+
+		if expose.Type != "http" && expose.Type != "tcp" {
+			return fmt.Errorf("expose type must be one of: http, tcp")
+		}
+	}
+
 	return nil
 }
 
@@ -118,8 +132,8 @@ type PupManifestCommand struct {
 
 /* Allow the user to expose certain ports in their container. */
 type PupManifestExposeConfig struct {
-	Type         string   `json:"type"`         // Freeform field, but we'll handle certain cases of "admin" or "public", "api"
-	TrafficType  string   `json:"trafficType"`  // HTTP, Raw TCP etc. Used by the frontend in addition to type to understand if something can be iframed.
+	Name         string   `json:"name"`         // Freeform field used to refer to this port in the frontend.
+	Type         string   `json:"type"`         // Must be one of: http, tcp
 	Port         int      `json:"port"`         // The port that is being listened on inside the container.
 	Interfaces   []string `json:"interfaces"`   // Designates that certain interfaces can be accessed on this port
 	ListenOnHost bool     `json:"listenOnHost"` // If true, the port will be accessible on the host network, otherwise it will listen on a private internal network interface.
@@ -140,6 +154,7 @@ type PupManifestPermissionGroup struct {
 	Description string   `json:"description"` // What does this permission group do (shown to user)
 	Severity    int      `json:"severity"`    // 1-3, 1: critical/danger, 2: makes changes, 3: read only stuff
 	Routes      []string `json:"routes"`      // http routes accessible for this group
+	Port        int      `json:"port"`        // port accessible for this group
 }
 
 /* Dependency specifies that this pup requires

--- a/pkg/sys.go
+++ b/pkg/sys.go
@@ -216,18 +216,20 @@ type NixSystemContainerConfigTemplatePupRequiresInternet struct {
 	PUP_IP string
 }
 
+type NixSystemContainerConfigTemplatePupTcpConnectionOtherPup struct {
+	NAME  string
+	ID    string
+	IP    string
+	PORTS []struct {
+		PORT int
+	}
+}
+
 type NixSystemContainerConfigTemplatePupTcpConnection struct {
 	NAME       string
 	ID         string
 	IP         string
-	OTHER_PUPS []struct {
-		NAME  string
-		ID    string
-		IP    string
-		PORTS []struct {
-			PORT int
-		}
-	}
+	OTHER_PUPS []NixSystemContainerConfigTemplatePupTcpConnectionOtherPup
 }
 
 type NixSystemContainerConfigTemplateValues struct {

--- a/pkg/sys.go
+++ b/pkg/sys.go
@@ -216,10 +216,25 @@ type NixSystemContainerConfigTemplatePupRequiresInternet struct {
 	PUP_IP string
 }
 
+type NixSystemContainerConfigTemplatePupTcpConnection struct {
+	NAME       string
+	ID         string
+	IP         string
+	OTHER_PUPS []struct {
+		NAME  string
+		ID    string
+		IP    string
+		PORTS []struct {
+			PORT int
+		}
+	}
+}
+
 type NixSystemContainerConfigTemplateValues struct {
 	DOGEBOX_HOST_IP         string
 	DOGEBOX_CONTAINER_CIDR  string
 	PUPS_REQUIRING_INTERNET []NixSystemContainerConfigTemplatePupRequiresInternet
+	PUPS_TCP_CONNECTIONS    []NixSystemContainerConfigTemplatePupTcpConnection
 }
 
 type NixFirewallTemplateValues struct {

--- a/pkg/system/nix/nix.go
+++ b/pkg/system/nix/nix.go
@@ -213,10 +213,18 @@ func (nm nixManager) UpdateSystemContainerConfiguration() error {
 		}
 	}
 
+	var pupsTcpConnections []dogeboxd.NixSystemContainerConfigTemplatePupTcpConnection
+	for _, state := range pupState {
+		for _, dependency := range state.Manifest.Dependencies {
+			// TODO: Do this.
+		}
+	}
+
 	values := dogeboxd.NixSystemContainerConfigTemplateValues{
 		DOGEBOX_HOST_IP:         hostIp,
 		DOGEBOX_CONTAINER_CIDR:  containerCidr,
 		PUPS_REQUIRING_INTERNET: pupsRequiringInternet,
+		PUPS_TCP_CONNECTIONS:    pupsTcpConnections,
 	}
 
 	return nm.updateSystemContainerConfiguration(values)

--- a/pkg/system/nix/templates/system_container_config.nix
+++ b/pkg/system/nix/templates/system_container_config.nix
@@ -16,19 +16,19 @@
       iptables -A FORWARD -s {{ .DOGEBOX_CONTAINER_CIDR }} -d {{ .DOGEBOX_HOST_IP }} -j ACCEPT
       iptables -A FORWARD -s {{ .DOGEBOX_HOST_IP }} -d {{ .DOGEBOX_CONTAINER_CIDR }} -j ACCEPT
 
-      {{ range .PUPS_TCP_CONNECTIONS }}
-        {{ $PUP := . }}
-        {{ range $PUP.OTHER_PUPS }}
-          {{ $OTHER_PUP := . }}
-          {{ range $OTHER_PUP.PORTS }}
-            # Connection FROM {{$PUP.ID}} ({{$PUP.NAME}}) to {{$OTHER_PUP.ID}} ({{$OTHER_PUP.NAME}})
-            iptables -A FORWARD -p tcp -s {{$PUP.IP}} -d {{$OTHER_PUP.IP} --dport {{.PORT}} -j ACCEPT
+      {{- range .PUPS_TCP_CONNECTIONS }}
+        {{- $PUP := . }}
+        {{- range $PUP.OTHER_PUPS }}
+          {{- $OTHER_PUP := . }}
+          {{- range .PORTS }}
+      # Connection FROM {{$PUP.ID}} ({{$PUP.NAME}}) to {{$OTHER_PUP.ID}} ({{$OTHER_PUP.NAME}})
+      iptables -A FORWARD -p tcp -s {{$PUP.IP}} -d {{$OTHER_PUP.IP}} --dport {{.PORT}} -j ACCEPT
 
-            # Connection BACK TO {{$PUP.ID}} ({{$PUP.NAME}}) from {{$OTHER_PUP.ID}} ({{$OTHER_PUP.NAME}})
-            iptables -A FORWARD -p tcp -s {{$OTHER_PUP.IP}} -d {{$PUP.IP}} --sport {{.PORT}} -j ACCEPT
-          {{end}}
-        {{end}}
-      {{end}}
+      # Connection BACK TO {{$PUP.ID}} ({{$PUP.NAME}}) from {{$OTHER_PUP.ID}} ({{$OTHER_PUP.NAME}})
+      iptables -A FORWARD -p tcp -s {{$OTHER_PUP.IP}} -d {{$PUP.IP}} --sport {{.PORT}} -j ACCEPT
+          {{- end}}
+        {{- end}}
+      {{- end}}
 
       {{ range .PUPS_REQUIRING_INTERNET }}
       # Explicitly block everything from {{.PUP_ID}} to all other pups.

--- a/pkg/system/nix/templates/system_container_config.nix
+++ b/pkg/system/nix/templates/system_container_config.nix
@@ -13,18 +13,32 @@
     enable = true;
     extraCommands = ''
       # Allow traffic to {{ .DOGEBOX_HOST_IP }} (host)
-      iptables -I FORWARD -s {{ .DOGEBOX_CONTAINER_CIDR }} -d {{ .DOGEBOX_HOST_IP }} -j ACCEPT
-      iptables -I FORWARD -s {{ .DOGEBOX_HOST_IP }} -d {{ .DOGEBOX_CONTAINER_CIDR }} -j ACCEPT
+      iptables -A FORWARD -s {{ .DOGEBOX_CONTAINER_CIDR }} -d {{ .DOGEBOX_HOST_IP }} -j ACCEPT
+      iptables -A FORWARD -s {{ .DOGEBOX_HOST_IP }} -d {{ .DOGEBOX_CONTAINER_CIDR }} -j ACCEPT
+
+      {{ range .PUPS_TCP_CONNECTIONS }}
+        {{ $PUP := . }}
+        {{ range $PUP.OTHER_PUPS }}
+          {{ $OTHER_PUP := . }}
+          {{ range $OTHER_PUP.PORTS }}
+            # Connection FROM {{$PUP.ID}} ({{$PUP.NAME}}) to {{$OTHER_PUP.ID}} ({{$OTHER_PUP.NAME}})
+            iptables -A FORWARD -p tcp -s {{$PUP.IP}} -d {{$OTHER_PUP.IP} --dport {{.PORT}} -j ACCEPT
+
+            # Connection BACK TO {{$PUP.ID}} ({{$PUP.NAME}}) from {{$OTHER_PUP.ID}} ({{$OTHER_PUP.NAME}})
+            iptables -A FORWARD -p tcp -s {{$OTHER_PUP.IP}} -d {{$PUP.IP}} --sport {{.PORT}} -j ACCEPT
+          {{end}}
+        {{end}}
+      {{end}}
 
       {{ range .PUPS_REQUIRING_INTERNET }}
       # Explicitly block everything from {{.PUP_ID}} to all other pups.
-      iptables -I FORWARD -s {{ .PUP_IP }} -d {{ $.DOGEBOX_CONTAINER_CIDR }} -j REJECT
+      iptables -A FORWARD -s {{ .PUP_IP }} -d {{ $.DOGEBOX_CONTAINER_CIDR }} -j REJECT
       # But allow {{.PUP_ID}} to talk to everything else (ie. the internet)
-      iptables -I FORWARD -s {{ .PUP_IP }} -j ACCEPT
+      iptables -A FORWARD -s {{ .PUP_IP }} -j ACCEPT
       {{end}}
 
       # Block all other traffic within {{ .DOGEBOX_CONTAINER_CIDR }}
-      iptables -I FORWARD -s {{ .DOGEBOX_CONTAINER_CIDR }} -d {{ .DOGEBOX_CONTAINER_CIDR }} -j REJECT
+      iptables -A FORWARD -s {{ .DOGEBOX_CONTAINER_CIDR }} -d {{ .DOGEBOX_CONTAINER_CIDR }} -j REJECT
 
       # Block everything else.
       iptables -A FORWARD -s {{ .DOGEBOX_CONTAINER_CIDR }} ! -d {{ .DOGEBOX_CONTAINER_CIDR }} -j REJECT

--- a/pkg/web/store.go
+++ b/pkg/web/store.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"log"
 	"net/http"
 	"time"
 
@@ -27,6 +28,7 @@ func (t api) getStoreList(w http.ResponseWriter, r *http.Request) {
 
 	available, err := t.sources.GetAll(forceRefresh)
 	if err != nil {
+		log.Println("Error fetching sources:", err)
 		sendErrorResponse(w, http.StatusInternalServerError, "Error fetching sources")
 		return
 	}


### PR DESCRIPTION
This allows pups to talk to each other via TCP, instead of HTTP, for interfaces.

nb. This will break most existing pups (which are really just the few little test ones we have) because I have renamed (and added validation) for a couple of fields, namely in the exposes section. 