### PR TITLE
Allow internal router to listen on :80 by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ mkbuild:
 build: build/dogeboxd build/dbx build/_dbxroot
 
 build/dogeboxd: clean, mkbuild
-	go build -o build/dogeboxd ./cmd/dogeboxd/. 
+	go build -o build/dogeboxd ./cmd/dogeboxd/.
 
 build/dbx: clean, mkbuild
 	go build -o build/dbx ./cmd/dbx/.
@@ -18,14 +18,11 @@ build/dbx: clean, mkbuild
 build/_dbxroot: clean, mkbuild
 	go build -o build/_dbxroot ./cmd/_dbxroot/.
 
-dev:
-	go run ./cmd/dogeboxd -v
-
 multipassdev:
 	go run ./cmd/dogeboxd -v -addr 0.0.0.0 -pups ~/
 
-orb:
-	go run ./cmd/dogeboxd -v --addr 0.0.0.0 --danger-dev --data ~/data --nix ~/data/nix --port 3000 --uiport 8080
+dev:
+	make && /run/wrappers/bin/dogeboxd -v --addr 0.0.0.0 --danger-dev --data ~/data --nix ~/data/nix --port 3000 --uiport 8080
 
 test:
 	go test -v ./test

--- a/cmd/dogeboxd/main.go
+++ b/cmd/dogeboxd/main.go
@@ -31,7 +31,7 @@ func main() {
 	flag.StringVar(&nixDir, "nix", "/etc/nixos/dogebox", "Directory to write dogebox-specific nix configuration to")
 	flag.StringVar(&uiDir, "uidir", "../dpanel/src", "Directory to find admin UI (dpanel)")
 	flag.IntVar(&uiPort, "uiport", 8081, "Port for serving admin UI (dpanel)")
-	flag.IntVar(&internalPort, "internal-port", 8082, "Internal Router Port")
+	flag.IntVar(&internalPort, "internal-port", 80, "Internal Router Port")
 	flag.BoolVar(&forcedRecovery, "force-recovery", false, "Force recovery mode")
 	flag.BoolVar(&dangerousDevMode, "danger-dev", false, "Enable dangerous development mode")
 	flag.BoolVar(&verbose, "v", false, "Be verbose")


### PR DESCRIPTION
This requires another nix security wrapper configured in `/etc/nixos/configuration.nix`

It must contain:

```nix
security.wrappers.dogeboxd = {
  source = "/path/to/dogeboxd/build/dogeboxd";
  capabilities = "cap_net_bind_service=+ep";
  owner = "username";
  group = "users";
};
```

Where `source` and `owner` have been updated to the correct values. `owner` should be your current non-root user.

This requires an equivalent change over in https://github.com/dogeorg/dogebox too.