### PR TITLE
Prevent containers from starting in recovery mode

### DIFF
--- a/cmd/dbx/cmd/enter-recovery-mode.go
+++ b/cmd/dbx/cmd/enter-recovery-mode.go
@@ -40,6 +40,6 @@ var enterRecoveryModeCmd = &cobra.Command{
 }
 
 func init() {
-	enterRecoveryModeCmd.Flags().StringP("dataDir", "d", "", "dogebox data dir")
+	enterRecoveryModeCmd.Flags().StringP("dataDir", "d", "/opt/dogebox", "dogebox data dir")
 	rootCmd.AddCommand(enterRecoveryModeCmd)
 }

--- a/cmd/dbx/cmd/is-recovery-mode.go
+++ b/cmd/dbx/cmd/is-recovery-mode.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	_ "embed"
+	"log"
+	"os"
+
+	"github.com/dogeorg/dogeboxd/pkg/system"
+	"github.com/spf13/cobra"
+)
+
+func exitBad(isSystemd bool) {
+	if isSystemd {
+		os.Exit(255)
+		return
+	}
+
+	os.Exit(1)
+}
+
+var isRecoveryModeCmd = &cobra.Command{
+	Use:   "is-recovery-mode",
+	Short: "Check if the device is in recovery mode.",
+	Run: func(cmd *cobra.Command, args []string) {
+		dataDir, err := cmd.Flags().GetString("data-dir")
+		if err != nil {
+			log.Println("Failed to get dataDir flag.")
+			exitBad(true)
+			return
+		}
+
+		systemd, err := cmd.Flags().GetBool("systemd")
+		if err != nil {
+			log.Println("Failed to get systemd flag.")
+			exitBad((true))
+			return
+		}
+
+		sm := system.NewStateManager(dataDir)
+		err = sm.Load()
+		if err != nil {
+			log.Println("Failed to load state manager: ", err)
+			exitBad(systemd)
+			return
+		}
+
+		isInRecoveryMode := system.ShouldEnterRecovery(dataDir, sm)
+
+		log.Println("Is in recovery mode:", isInRecoveryMode)
+
+		if isInRecoveryMode {
+			exitBad(systemd)
+			return
+		}
+
+		os.Exit(0)
+	},
+}
+
+func init() {
+	isRecoveryModeCmd.Flags().StringP("data-dir", "d", "/opt/dogebox", "dogebox data dir")
+	isRecoveryModeCmd.Flags().BoolP("systemd", "", false, "Exits with 255 instead of 1 if in recovery mode.")
+	rootCmd.AddCommand(isRecoveryModeCmd)
+}

--- a/cmd/dbx/cmd/is-recovery-mode.go
+++ b/cmd/dbx/cmd/is-recovery-mode.go
@@ -44,7 +44,7 @@ var isRecoveryModeCmd = &cobra.Command{
 			return
 		}
 
-		isInRecoveryMode := system.ShouldEnterRecovery(dataDir, sm)
+		isInRecoveryMode := system.IsRecoveryMode(dataDir, sm)
 
 		log.Println("Is in recovery mode:", isInRecoveryMode)
 

--- a/cmd/dogeboxd/main.go
+++ b/cmd/dogeboxd/main.go
@@ -67,6 +67,12 @@ func main() {
 	}
 
 	if recoveryMode {
+		if err := system.UnforceRecoveryNextBoot(dataDir); err != nil {
+			log.Printf("Failed to unset recovery next boot: %+v", err)
+		}
+	}
+
+	if recoveryMode {
 		log.Println("********************************************************************************")
 		log.Println("************************ ENTERING DOGEBOX RECOVERY MODE ************************")
 		log.Println("********************************************************************************")

--- a/cmd/dogeboxd/main.go
+++ b/cmd/dogeboxd/main.go
@@ -67,15 +67,17 @@ func main() {
 	}
 
 	if recoveryMode {
-		if err := system.UnforceRecoveryNextBoot(dataDir); err != nil {
-			log.Printf("Failed to unset recovery next boot: %+v", err)
+		if err := system.DidEnterRecovery(dataDir); err != nil {
+			log.Printf("Failed to call DidEnterRecovery: %+v", err)
 		}
-	}
 
-	if recoveryMode {
 		log.Println("********************************************************************************")
 		log.Println("************************ ENTERING DOGEBOX RECOVERY MODE ************************")
 		log.Println("********************************************************************************")
+	} else {
+		if err := system.UnforceRecoveryNextBoot(dataDir); err != nil {
+			log.Printf("Failed to call UnforceRecoveryNextBoot: %+v", err)
+		}
 	}
 
 	if dangerousDevMode {

--- a/pkg/sys.go
+++ b/pkg/sys.go
@@ -198,6 +198,8 @@ type NixPupContainerServiceValues struct {
 }
 
 type NixPupContainerTemplateValues struct {
+	DATA_DIR string
+
 	PUP_ID      string
 	PUP_ENABLED bool
 	INTERNAL_IP string

--- a/pkg/system/nix/nix.go
+++ b/pkg/system/nix/nix.go
@@ -143,6 +143,7 @@ func (nm nixManager) WritePupFile(
 	}
 
 	values := dogeboxd.NixPupContainerTemplateValues{
+		DATA_DIR:    nm.config.DataDir,
 		PUP_ID:      state.ID,
 		PUP_ENABLED: state.Enabled,
 		INTERNAL_IP: state.IP,

--- a/pkg/system/nix/templates/pup_container.nix
+++ b/pkg/system/nix/templates/pup_container.nix
@@ -1,4 +1,4 @@
-{ config, libs, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
 let
   pupOverlay = self: super: {
@@ -118,4 +118,7 @@ in
       {{end}}
     };
   };
-}  
+
+  # Add a start condition to this container so it will only start in non-recovery mode.
+  systemd.services."container@pup-{{.PUP_ID}}".serviceConfig.ExecCondition = "/run/wrappers/bin/dbx is-recovery-mode --data-dir {{.DATA_DIR}} --systemd";
+}

--- a/pkg/system/recovery.go
+++ b/pkg/system/recovery.go
@@ -14,9 +14,40 @@ import (
 var VALID_RECOVERY_FILES = []string{"RECOVERY", "RECOVERY.TXT"}
 
 // This function should do detection on whether or not we should enter our "Recovery Mode".
-// This can always be overriden by a CLI flag if necessary.
+// This can always be overriden by a CLI flag if necessary. This will not return true if the
+// current instance of dogeboxd has booted in recovery. Use `IsRecoveryMode()` for that.
 func ShouldEnterRecovery(dogeboxDataDir string, sm dogeboxd.StateManager) bool {
 	return hasExternalRecoveryTXT() || isInitialConfiguration(sm) || HasForceRecoveryFile(dogeboxDataDir)
+}
+
+func IsRecoveryMode(dogeboxDataDir string, sm dogeboxd.StateManager) bool {
+	if ShouldEnterRecovery(dogeboxDataDir, sm) {
+		return true
+	}
+
+	bootedRecoveryPath := filepath.Join(dogeboxDataDir, "booted_recovery")
+	if _, err := os.Stat(bootedRecoveryPath); err == nil {
+		return true
+	}
+	return false
+}
+
+func DidEnterRecovery(dogeboxDataDir string) error {
+	forceRecoveryPath := filepath.Join(dogeboxDataDir, "force_recovery_next_boot")
+	if _, err := os.Stat(forceRecoveryPath); err == nil {
+		if err := os.Remove(forceRecoveryPath); err != nil {
+			return fmt.Errorf("failed to remove force_recovery_next_boot file: %w", err)
+		}
+	}
+
+	bootedRecoveryPath := filepath.Join(dogeboxDataDir, "booted_recovery")
+	file, err := os.Create(bootedRecoveryPath)
+	if err != nil {
+		return fmt.Errorf("failed to create booted_recovery file: %w", err)
+	}
+	defer file.Close()
+
+	return nil
 }
 
 func ForceRecoveryNextBoot(dataDir string) error {
@@ -31,12 +62,19 @@ func ForceRecoveryNextBoot(dataDir string) error {
 
 func UnforceRecoveryNextBoot(dataDir string) error {
 	filePath := filepath.Join(dataDir, "force_recovery_next_boot")
-	if _, err := os.Stat(filePath); os.IsNotExist(err) {
-		return nil
+	if _, err := os.Stat(filePath); err == nil {
+		if err := os.Remove(filePath); err != nil {
+			return fmt.Errorf("failed to remove force recovery file: %w", err)
+		}
 	}
-	if err := os.Remove(filePath); err != nil {
-		return fmt.Errorf("failed to remove force recovery file: %w", err)
+
+	bootedRecoveryPath := filepath.Join(dataDir, "booted_recovery")
+	if _, err := os.Stat(bootedRecoveryPath); err == nil {
+		if err := os.Remove(bootedRecoveryPath); err != nil {
+			return fmt.Errorf("failed to remove booted_recovery file: %w", err)
+		}
 	}
+
 	return nil
 }
 

--- a/pkg/system/recovery.go
+++ b/pkg/system/recovery.go
@@ -31,6 +31,9 @@ func ForceRecoveryNextBoot(dataDir string) error {
 
 func UnforceRecoveryNextBoot(dataDir string) error {
 	filePath := filepath.Join(dataDir, "force_recovery_next_boot")
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return nil
+	}
 	if err := os.Remove(filePath); err != nil {
 		return fmt.Errorf("failed to remove force recovery file: %w", err)
 	}
@@ -40,10 +43,6 @@ func UnforceRecoveryNextBoot(dataDir string) error {
 func HasForceRecoveryFile(dataDir string) bool {
 	filePath := filepath.Join(dataDir, "force_recovery_next_boot")
 	if _, err := os.Stat(filePath); err == nil {
-		// We want to remove it as soon as we've read it.
-		if err := os.Remove(filePath); err != nil {
-			fmt.Printf("Failed to remove force recovery file: %v\n", err)
-		}
 		return true
 	}
 	return false


### PR DESCRIPTION
This prevents any pup containers from starting if we're booting into recovery mode.

TODO:

- [x] `dbx is-recovery-mode` returns `false` even if `dbx` is currently in recovery mode, but is not _scheduled_ to be next boot. Will fix.

This requires another security wrapper in your `/etc/nixos/configuration.nix`, hopefully the last one.

```
  security.wrappers.dbx = {
    source = "/Users/adam/code/doge/dogeboxd/build/dbx";
    owner = "adam";
    group = "users";
  };
```

Where `source` & `owner` are updated.