### PR TITLE
Inject relevant container environment variables

### DIFF
--- a/pkg/config.go
+++ b/pkg/config.go
@@ -14,3 +14,10 @@ type ServerConfig struct {
 	UiPort          int
 	DevMode         bool
 }
+
+func GetSystemEnvironmentVariablesForContainer() map[string]string {
+	return map[string]string{
+		"DBX_HOST": "10.69.0.1",
+		"DBX_PORT": "80",
+	}
+}

--- a/pkg/pup_manager.go
+++ b/pkg/pup_manager.go
@@ -12,8 +12,10 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
+	"unicode"
 
 	"github.com/Masterminds/semver"
 	"github.com/dogeorg/dogeboxd/pkg/pup"
@@ -680,6 +682,53 @@ func (t PupManager) updateMonitoredPups() {
 // the frontend with status.
 func (t PupManager) FastPollPup(id string) {
 	t.monitor.GetFastMonChannel() <- fmt.Sprintf("container@pup-%s.service", id)
+}
+
+func (t PupManager) GetPupSpecificEnvironmentVariablesForContainer(pupID string) map[string]string {
+	env := map[string]string{
+		"DBX_PUP_ID": pupID,
+		"DBX_PUP_IP": t.state[pupID].IP,
+	}
+
+	// Iterate over each of our configured interfaces, and expose the host and port of each
+	for _, iface := range t.state[pupID].Manifest.Dependencies {
+		providerPup, ok := t.state[t.state[pupID].Providers[iface.InterfaceName]]
+		if !ok {
+			continue
+		}
+
+		interfaceName := toValidEnvKey(iface.InterfaceName)
+
+		var providerPupExposes pup.PupManifestExposeConfig
+
+	outer:
+		for _, expose := range providerPup.Manifest.Container.Exposes {
+			for _, exposeInterface := range expose.Interfaces {
+				if exposeInterface == iface.InterfaceName {
+					providerPupExposes = expose
+					break outer
+				}
+			}
+		}
+
+		env["DBX_IFACE_"+interfaceName+"_NAME"] = providerPupExposes.Name
+		env["DBX_IFACE_"+interfaceName+"_HOST"] = providerPup.IP
+		env["DBX_IFACE_"+interfaceName+"_PORT"] = strconv.Itoa(providerPupExposes.Port)
+	}
+
+	return env
+}
+
+func toValidEnvKey(s string) string {
+	s = strings.ReplaceAll(s, "-", "_")
+	s = strings.ReplaceAll(s, " ", "_")
+	s = strings.Map(func(r rune) rune {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' {
+			return r
+		}
+		return -1
+	}, s)
+	return strings.ToUpper(s)
 }
 
 /*****************************************************************************/

--- a/pkg/sys.go
+++ b/pkg/sys.go
@@ -191,14 +191,16 @@ type ManifestSourceConfiguration struct {
 	Type        string `json:"type"`
 }
 
+type EnvEntry struct {
+	KEY string
+	VAL string
+}
+
 type NixPupContainerServiceValues struct {
 	NAME string
 	EXEC string
 	CWD  string
-	ENV  []struct {
-		KEY string
-		VAL string
-	}
+	ENV  []EnvEntry
 }
 
 type NixPupContainerTemplateValues struct {
@@ -215,6 +217,8 @@ type NixPupContainerTemplateValues struct {
 	PUP_PATH     string
 	NIX_FILE     string
 	SERVICES     []NixPupContainerServiceValues
+	PUP_ENV      []EnvEntry
+	GLOBAL_ENV   []EnvEntry
 }
 
 type NixSystemContainerConfigTemplatePupRequiresInternet struct {

--- a/pkg/system/nix/templates/pup_container.nix
+++ b/pkg/system/nix/templates/pup_container.nix
@@ -120,7 +120,15 @@ in
           WorkingDirectory = "{{.CWD}}";
 
           Environment = [
-            {{range .ENV}}"{{.KEY}}={{.VAL}}"{{end}}
+            {{range .ENV}}
+            "{{.KEY}}={{.VAL}}"
+            {{end}}
+            {{range $.PUP_ENV}}
+            "{{.KEY}}={{.VAL}}"
+            {{end}}
+            {{range $.GLOBAL_ENV}}
+            "{{.KEY}}={{.VAL}}"
+            {{end}}
           ];
 
           PrivateTmp = true;


### PR DESCRIPTION
This will inject a bunch of environment variables that can be read by pups. 

This is mainly needed for pups that want to talk TCP to each other. With HTTP you would just hit the dbx router at `/pup/${interfaceName}` but that's not possible with TCP connections.

With this, we inject an environment variable named `DBX_IFACE_${IFACE_NAME}_HOST` and `DBX_IFACE_${IFACE_NAME}_PORT` that the process can read and use to understand where to connect to.

A list of things injected:

```bash
# Always
DBX_HOST=10.69.0.1               # Address of dogeboxd
DBX_PORT=80                      # Port for dogeboxd pup router
DBX_PUP_IP=10.69.0.4             # The IP address assigned to this pup
DBX_PUP_ID=1234snip              # The ID of this pup

# Per-interface (where $ is replaced with the interface name)
DBX_IFACE_$_NAME=count-server          # The name of the pup assigned as the provider for this interface
DBX_IFACE_$_HOST=10.69.0.2             # The IP address of the pup assigned as the provider for this interface
DBX_IFACE_$_PORT=9999                  # The port that this interface is available on.
````