### PR TITLE
Provider Updates & Tidies

### DIFF
--- a/cmd/dbx/cmd/can-pup-start.go
+++ b/cmd/dbx/cmd/can-pup-start.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	_ "embed"
+	"log"
+	"os"
+
+	"github.com/dogeorg/dogeboxd/cmd/dbx/utils"
+	dogeboxd "github.com/dogeorg/dogeboxd/pkg"
+	source "github.com/dogeorg/dogeboxd/pkg/sources"
+	"github.com/dogeorg/dogeboxd/pkg/system"
+	"github.com/spf13/cobra"
+)
+
+var canPupStartCmd = &cobra.Command{
+	Use:   "can-pup-start",
+	Short: "Check if a pup can start.",
+	Run: func(cmd *cobra.Command, args []string) {
+		dataDir, err := cmd.Flags().GetString("data-dir")
+		if err != nil {
+			log.Println("Failed to get dataDir flag.")
+			utils.ExitBad(true)
+			return
+		}
+
+		systemd, err := cmd.Flags().GetBool("systemd")
+		if err != nil {
+			log.Println("Failed to get systemd flag.")
+			utils.ExitBad(true)
+			return
+		}
+
+		pupId, err := cmd.Flags().GetString("pup-id")
+		if err != nil {
+			log.Println("Failed to get pup-id flag.")
+			utils.ExitBad(true)
+			return
+		}
+
+		sm := system.NewStateManager(dataDir)
+		err = sm.Load()
+		if err != nil {
+			log.Println("Failed to load state manager: ", err)
+			utils.ExitBad(systemd)
+			return
+		}
+
+		isInRecoveryMode := system.IsRecoveryMode(dataDir, sm)
+
+		if isInRecoveryMode {
+			log.Println("Can start: false")
+			utils.ExitBad(systemd)
+			return
+		}
+
+		// Ideally we wouldn't have to init all these things.
+		systemMonitor := system.NewSystemMonitor(dogeboxd.ServerConfig{})
+
+		pupManager, err := dogeboxd.NewPupManager(dataDir, "/tmp", systemMonitor)
+		if err != nil {
+			log.Println("Failed to load PupManager: ", err)
+			utils.ExitBad(systemd)
+			return
+		}
+
+		sourceManager := source.NewSourceManager(dogeboxd.ServerConfig{}, sm, pupManager)
+		pupManager.SetSourceManager(sourceManager)
+
+		canStart, err := pupManager.CanPupStart(pupId)
+		if err != nil {
+			log.Println("Failed to check if pup can start: ", err)
+			utils.ExitBad(systemd)
+			return
+		}
+
+		if canStart {
+			log.Println("Can start: true")
+			os.Exit(0)
+		}
+
+		log.Println("Can start: false")
+		utils.ExitBad(systemd)
+	},
+}
+
+func init() {
+	canPupStartCmd.Flags().StringP("pup-id", "p", "", "id of pup to check")
+	canPupStartCmd.Flags().StringP("data-dir", "d", "/opt/dogebox", "dogebox data dir")
+	canPupStartCmd.Flags().BoolP("systemd", "", false, "Exits with 255 instead of 1 if in recovery mode.")
+	canPupStartCmd.MarkFlagRequired("data-dir")
+	canPupStartCmd.MarkFlagRequired("pup-id")
+	rootCmd.AddCommand(canPupStartCmd)
+}

--- a/cmd/dbx/cmd/is-recovery-mode.go
+++ b/cmd/dbx/cmd/is-recovery-mode.go
@@ -5,18 +5,10 @@ import (
 	"log"
 	"os"
 
+	"github.com/dogeorg/dogeboxd/cmd/dbx/utils"
 	"github.com/dogeorg/dogeboxd/pkg/system"
 	"github.com/spf13/cobra"
 )
-
-func exitBad(isSystemd bool) {
-	if isSystemd {
-		os.Exit(255)
-		return
-	}
-
-	os.Exit(1)
-}
 
 var isRecoveryModeCmd = &cobra.Command{
 	Use:   "is-recovery-mode",
@@ -25,14 +17,14 @@ var isRecoveryModeCmd = &cobra.Command{
 		dataDir, err := cmd.Flags().GetString("data-dir")
 		if err != nil {
 			log.Println("Failed to get dataDir flag.")
-			exitBad(true)
+			utils.ExitBad(true)
 			return
 		}
 
 		systemd, err := cmd.Flags().GetBool("systemd")
 		if err != nil {
 			log.Println("Failed to get systemd flag.")
-			exitBad((true))
+			utils.ExitBad(true)
 			return
 		}
 
@@ -40,7 +32,7 @@ var isRecoveryModeCmd = &cobra.Command{
 		err = sm.Load()
 		if err != nil {
 			log.Println("Failed to load state manager: ", err)
-			exitBad(systemd)
+			utils.ExitBad(systemd)
 			return
 		}
 
@@ -49,7 +41,7 @@ var isRecoveryModeCmd = &cobra.Command{
 		log.Println("Is in recovery mode:", isInRecoveryMode)
 
 		if isInRecoveryMode {
-			exitBad(systemd)
+			utils.ExitBad(systemd)
 			return
 		}
 

--- a/cmd/dbx/main.go
+++ b/cmd/dbx/main.go
@@ -1,6 +1,8 @@
 package main
 
-import "github.com/dogeorg/dogeboxd/cmd/dbx/cmd"
+import (
+	"github.com/dogeorg/dogeboxd/cmd/dbx/cmd"
+)
 
 func main() {
 	cmd.Execute()

--- a/cmd/dbx/utils/utils.go
+++ b/cmd/dbx/utils/utils.go
@@ -1,0 +1,12 @@
+package utils
+
+import "os"
+
+func ExitBad(isSystemd bool) {
+	if isSystemd {
+		os.Exit(255)
+		return
+	}
+
+	os.Exit(1)
+}

--- a/pkg/pup_manager.go
+++ b/pkg/pup_manager.go
@@ -481,6 +481,8 @@ func (t PupManager) UpdateMetrics(u UpdateMetrics) {
 	}
 }
 
+// This function only checks pup-specific conditions, it does not check
+// the rest of the system is ready for a pup to start.
 func (t PupManager) CanPupStart(pupId string) (bool, error) {
 	pup, ok := t.state[pupId]
 	if !ok {
@@ -494,10 +496,13 @@ func (t PupManager) CanPupStart(pupId string) (bool, error) {
 		return false, nil
 	}
 
+	// TODO: This doesn't work when being called from our dbx CLI
+	//       as our system updates aren't running.
+
 	// If a dep isn't running, don't start.
-	if len(report.Issues.DepsNotRunning) > 0 {
-		return false, nil
-	}
+	// if len(report.Issues.DepsNotRunning) > 0 {
+	// 	return false, nil
+	// }
 
 	return true, nil
 }

--- a/pkg/pup_manager.go
+++ b/pkg/pup_manager.go
@@ -481,8 +481,34 @@ func (t PupManager) UpdateMetrics(u UpdateMetrics) {
 	}
 }
 
-// Modify provided pup to update warning flags
-func (t PupManager) healthCheckPupState(pup *PupState) {
+func (t PupManager) CanPupStart(pupId string) (bool, error) {
+	pup, ok := t.state[pupId]
+	if !ok {
+		return false, errors.New("no such pup")
+	}
+
+	report := t.GetPupHealthState(pup)
+
+	// If we still need config or deps, don't start.
+	if report.NeedsConf || report.NeedsDeps {
+		return false, nil
+	}
+
+	// If a dep isn't running, don't start.
+	if len(report.Issues.DepsNotRunning) > 0 {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+type PupHealthStateReport struct {
+	Issues    PupIssues
+	NeedsConf bool
+	NeedsDeps bool
+}
+
+func (t PupManager) GetPupHealthState(pup *PupState) PupHealthStateReport {
 	// are our required config fields set?
 	configSet := true
 loop:
@@ -522,17 +548,26 @@ loop:
 		}
 	}
 
-	// Update pupState
-	pup.NeedsConf = !configSet
-	pup.NeedsDeps = !depsMet
-
-	// Update pupStats
-	issues := PupIssues{
-		DepsNotRunning: depsNotRunning,
-		// TODO: HealthWarnings
-		// TODO: UpdateAvailable
+	report := PupHealthStateReport{
+		Issues: PupIssues{
+			DepsNotRunning: depsNotRunning,
+			// TODO: HealthWarnings
+			// TODO: UpdateAvailable
+		},
+		NeedsConf: !configSet,
+		NeedsDeps: !depsMet,
 	}
-	t.stats[pup.ID].Issues = issues
+
+	return report
+}
+
+// Modify provided pup to update warning flags
+func (t PupManager) healthCheckPupState(pup *PupState) {
+	report := t.GetPupHealthState(pup)
+
+	pup.NeedsConf = report.NeedsConf
+	pup.NeedsDeps = report.NeedsDeps
+	t.stats[pup.ID].Issues = report.Issues
 }
 
 // This function calculates a DependencyReport for every

--- a/pkg/system/nix/nix.go
+++ b/pkg/system/nix/nix.go
@@ -271,7 +271,7 @@ func (nm nixManager) UpdateSystemContainerConfiguration() error {
 
 			if _, ok := otherPupsById[providerPup.ID]; !ok {
 				otherPupsById[providerPup.ID] = dogeboxd.NixSystemContainerConfigTemplatePupTcpConnectionOtherPup{
-					NAME: providerPup.ID,
+					NAME: providerPup.Manifest.Meta.Name,
 					ID:   providerPup.ID,
 					IP:   providerPup.IP,
 					PORTS: []struct {
@@ -292,7 +292,7 @@ func (nm nixManager) UpdateSystemContainerConfiguration() error {
 		}
 
 		pupsTcpConnections = append(pupsTcpConnections, dogeboxd.NixSystemContainerConfigTemplatePupTcpConnection{
-			NAME:       state.ID,
+			NAME:       state.Manifest.Meta.Name,
 			ID:         state.ID,
 			IP:         state.IP,
 			OTHER_PUPS: otherPups,

--- a/pkg/system/nix/templates/pup_container.nix
+++ b/pkg/system/nix/templates/pup_container.nix
@@ -142,5 +142,5 @@ in
   };
 
   # Add a start condition to this container so it will only start in non-recovery mode.
-  systemd.services."container@pup-{{.PUP_ID}}".serviceConfig.ExecCondition = "/run/wrappers/bin/dbx is-recovery-mode --data-dir {{.DATA_DIR}} --systemd";
+  systemd.services."container@pup-{{.PUP_ID}}".serviceConfig.ExecCondition = "/run/wrappers/bin/dbx can-pup-start --data-dir {{.DATA_DIR}} --systemd --pup-id {{.PUP_ID}}";
 }


### PR DESCRIPTION
This prevents a unnecessary nix rebuilds when a pup is not in a "ready" state (has unmet dependencies etc).

This also adds `dbx can-pup-start --pup-id 123` that will return 0/1 if a pup is allowed to start (not in recovery mode, dependencies met etc) that will prevent a pup from even attempting to start.