### PR TITLE
Add meta.upstreamVersions to manifest

### DIFF
--- a/pkg/pup/manifest.go
+++ b/pkg/pup/manifest.go
@@ -87,6 +87,8 @@ type PupManifestMeta struct {
 	ShortDescription string `json:"shortDescription"`
 	// Optional, longer description. Used for store listings.
 	LongDescription string `json:"longDescription"`
+	// A key value pair of upstream versions that this pup ships with.
+	UpstreamVersions map[string]string `json:"upstreamVersions"`
 }
 
 /* PupManfiestV1Container contains information about the


### PR DESCRIPTION
This will allow us to display upstream version metadata on pups, different to the version of the actual pup.

![image](https://github.com/user-attachments/assets/38c5826b-4e25-4f7d-8f35-dd8135ac727a)

