### PR TITLE
Nix Snapshots

### DIFF
--- a/cmd/dogeboxd/main.go
+++ b/cmd/dogeboxd/main.go
@@ -65,6 +65,15 @@ func main() {
 		}
 	}
 
+	// Check if nixdir exists and create if not
+	if _, err := os.Stat(nixDir); os.IsNotExist(err) {
+		log.Printf("Specified nixdir %s does not exist, creating it", nixDir)
+		err := os.MkdirAll(nixDir, 0755)
+		if err != nil {
+			log.Fatalf("Failed to create nixdir: %v", err)
+		}
+	}
+
 	stateManager := system.NewStateManager(dataDir)
 	err := stateManager.Load()
 	if err != nil {

--- a/pkg/sys.go
+++ b/pkg/sys.go
@@ -277,9 +277,15 @@ type NixNetworkTemplateValues struct {
 	WIFI_PASSWORD string
 }
 
+type NixPatchApplyOptions struct {
+	RebuildBoot bool
+}
+
 type NixPatch interface {
 	State() string
 	Apply() error
+	ApplyCustom(options NixPatchApplyOptions) error
+
 	Cancel() error
 
 	UpdateSystemContainerConfiguration(values NixSystemContainerConfigTemplateValues)

--- a/pkg/system/network/linux.go
+++ b/pkg/system/network/linux.go
@@ -160,7 +160,7 @@ func (t NetworkManagerLinux) SetPendingNetwork(selectedNetwork dogeboxd.Selected
 	return t.sm.Save()
 }
 
-func (t NetworkManagerLinux) TryConnect() error {
+func (t NetworkManagerLinux) TryConnect(nixPatch dogeboxd.NixPatch) error {
 	state := t.sm.Get().Network
 
 	if state.PendingNetwork == nil {
@@ -182,10 +182,7 @@ func (t NetworkManagerLinux) TryConnect() error {
 		return err
 	}
 
-	err = persistor.Persist(state.PendingNetwork)
-	if err != nil {
-		return err
-	}
+	persistor.Persist(nixPatch, state.PendingNetwork)
 
 	// Swap out pending for current.
 	state.CurrentNetwork = state.PendingNetwork

--- a/pkg/system/network/persistor/nix.go
+++ b/pkg/system/network/persistor/nix.go
@@ -12,7 +12,7 @@ type NetworkPersistorNix struct {
 	nix dogeboxd.NixManager
 }
 
-func (t NetworkPersistorNix) Persist(network dogeboxd.SelectedNetwork) error {
+func (t NetworkPersistorNix) Persist(nixPatch dogeboxd.NixPatch, network dogeboxd.SelectedNetwork) {
 	values := dogeboxd.NixNetworkTemplateValues{}
 
 	switch network := network.(type) {
@@ -32,5 +32,5 @@ func (t NetworkPersistorNix) Persist(network dogeboxd.SelectedNetwork) error {
 		}
 	}
 
-	return t.nix.UpdateNetwork(values)
+	t.nix.UpdateNetwork(nixPatch, values)
 }

--- a/pkg/system/nix/nix-patch.go
+++ b/pkg/system/nix/nix-patch.go
@@ -1,0 +1,188 @@
+package nix
+
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+//go:embed templates/pup_container.nix
+var rawPupContainerTemplate []byte
+
+//go:embed templates/system_container_config.nix
+var rawSystemContainerConfigTemplate []byte
+
+//go:embed templates/firewall.nix
+var rawFirewallTemplate []byte
+
+//go:embed templates/system.nix
+var rawSystemTemplate []byte
+
+//go:embed templates/dogebox.nix
+var rawIncludesFileTemplate []byte
+
+//go:embed templates/network.nix
+var rawNetworkTemplate []byte
+
+const (
+	NixPatchStatePending     string = "pending"
+	NixPatchStateCancelled   string = "cancelled"
+	NixPatchStateApplying    string = "applying"
+	NixPatchStateApplied     string = "applied"
+	NixPatchStateRollingBack string = "rolling back"
+	NixPatchStateErrored     string = "errored"
+)
+
+type NixPatch struct {
+	nm          nixManager
+	snapshotDir string
+	state       string
+	operations  []string
+	error       error
+}
+
+func (np *NixPatch) State() string {
+	return np.state
+}
+
+func (np *NixPatch) add(operation string) error {
+	if np.state != NixPatchStatePending {
+		return errors.New("patch already applied or cancelled")
+	}
+
+	np.operations = append(np.operations, operation)
+	return nil
+}
+
+func (np *NixPatch) Apply() error {
+	if np.state != NixPatchStatePending {
+		return errors.New("patch already applied or cancelled")
+	}
+
+	np.state = NixPatchStateApplying
+
+	if err := np.snapshot(); err != nil {
+		np.state = NixPatchStateErrored
+		np.error = err
+		return fmt.Errorf("failed to snapshot: %w", err)
+	}
+
+	np.state = NixPatchStateApplying
+
+	for _, operation := range np.operations {
+		log.Printf("applying operation: %s", operation)
+		// if operationApplyError != nil {
+		// 	return np.triggerRollback(operationApplyError)
+		// }
+	}
+
+	if err := np.nm.Rebuild(); err != nil {
+		// We failed.
+		// Roll back our changes.
+		return np.triggerRollback(err)
+	}
+
+	np.state = NixPatchStateApplied
+
+	return nil
+}
+
+func (np *NixPatch) Cancel() error {
+	if np.state != NixPatchStatePending {
+		return errors.New("patch already applied or cancelled")
+	}
+
+	np.state = NixPatchStateCancelled
+	return nil
+}
+
+func (np *NixPatch) snapshot() error {
+	timestamp := time.Now().Unix()
+
+	snapshotDir := filepath.Join(np.nm.config.TmpDir, fmt.Sprintf("nix-patch-%d", timestamp))
+	err := os.MkdirAll(snapshotDir, 0750)
+	if err != nil {
+		np.state = NixPatchStateErrored
+		np.error = err
+		return fmt.Errorf("failed to create snapshot directory: %w", err)
+	}
+
+	np.snapshotDir = snapshotDir
+	return np.copyDirectory(np.nm.config.NixDir, np.snapshotDir)
+}
+
+func (np *NixPatch) triggerRollback(err error) error {
+	np.state = NixPatchStateRollingBack
+	np.error = err
+
+	if err := np.doRollback(); err != nil {
+		return fmt.Errorf("failed to actually roll back: %w", err)
+	}
+
+	np.state = NixPatchStateErrored
+	return err
+}
+
+func (np *NixPatch) doRollback() error {
+	if np.state != NixPatchStateApplying {
+		return nil
+	}
+
+	np.state = NixPatchStateRollingBack
+
+	err := os.RemoveAll(np.nm.config.NixDir)
+	if err != nil {
+		return fmt.Errorf("failed to remove nixDir: %w", err)
+	}
+
+	return np.copyDirectory(np.snapshotDir, np.nm.config.NixDir)
+}
+
+func (np *NixPatch) copyDirectory(srcDir, destDir string) error {
+	err := filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+
+		destPath := filepath.Join(destDir, relPath)
+
+		if info.IsDir() {
+			return os.MkdirAll(destPath, info.Mode())
+		}
+
+		srcFile, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer srcFile.Close()
+
+		destFile, err := os.Create(destPath)
+		if err != nil {
+			return err
+		}
+		defer destFile.Close()
+
+		_, err = io.Copy(destFile, srcFile)
+		if err != nil {
+			return err
+		}
+
+		return os.Chmod(destPath, info.Mode())
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to copy files: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/system/nix/nix-patch.go
+++ b/pkg/system/nix/nix-patch.go
@@ -1,14 +1,20 @@
 package nix
 
 import (
+	"bytes"
+	"crypto/rand"
 	_ "embed"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
+	"text/template"
 	"time"
+
+	dogeboxd "github.com/dogeorg/dogeboxd/pkg"
 )
 
 //go:embed templates/pup_container.nix
@@ -38,31 +44,59 @@ const (
 	NixPatchStateErrored     string = "errored"
 )
 
-type NixPatch struct {
+var _ dogeboxd.NixPatch = &nixPatch{}
+
+type PatchOperation struct {
+	Name      string
+	Operation func() error
+}
+
+type nixPatch struct {
+	id          string
 	nm          nixManager
 	snapshotDir string
 	state       string
-	operations  []string
+	operations  []PatchOperation
 	error       error
 }
 
-func (np *NixPatch) State() string {
+func NewNixPatch(nm nixManager) dogeboxd.NixPatch {
+	id := make([]byte, 6)
+	rand.Read(id)
+	patchID := hex.EncodeToString(id)
+
+	p := &nixPatch{
+		id:    patchID,
+		nm:    nm,
+		state: NixPatchStatePending,
+	}
+
+	log.Printf("[patch-%s] Created new nix patch", p.id)
+
+	return p
+}
+
+func (np *nixPatch) State() string {
 	return np.state
 }
 
-func (np *NixPatch) add(operation string) error {
+func (np *nixPatch) add(name string, op func() error) error {
 	if np.state != NixPatchStatePending {
 		return errors.New("patch already applied or cancelled")
 	}
 
-	np.operations = append(np.operations, operation)
+	log.Printf("[patch-%s] Adding pending operation %s", np.id, name)
+	np.operations = append(np.operations, PatchOperation{Name: name, Operation: op})
+
 	return nil
 }
 
-func (np *NixPatch) Apply() error {
+func (np *nixPatch) Apply() error {
 	if np.state != NixPatchStatePending {
 		return errors.New("patch already applied or cancelled")
 	}
+
+	log.Printf("[patch-%s] Applying nix patch with %d operations", np.id, len(np.operations))
 
 	np.state = NixPatchStateApplying
 
@@ -75,24 +109,34 @@ func (np *NixPatch) Apply() error {
 	np.state = NixPatchStateApplying
 
 	for _, operation := range np.operations {
-		log.Printf("applying operation: %s", operation)
-		// if operationApplyError != nil {
-		// 	return np.triggerRollback(operationApplyError)
-		// }
+		log.Printf("[patch-%s] Applying operation: %s", np.id, operation.Name)
+		if err := operation.Operation(); err != nil {
+			return np.triggerRollback(err)
+		}
 	}
+
+	log.Printf("[patch-%s] Applied all patch operations, rebuilding..", np.id)
 
 	if err := np.nm.Rebuild(); err != nil {
 		// We failed.
 		// Roll back our changes.
+		log.Printf("[patch-%s] Failed to rebuild, rolling back.. %v", np.id, err)
 		return np.triggerRollback(err)
 	}
 
+	if err := os.RemoveAll(np.snapshotDir); err != nil {
+		log.Printf("[patch-%s] Warning: Failed to remove snapshot directory: %v", np.id, err)
+	} else {
+		log.Printf("[patch-%s] Removed snapshot directory: %s", np.id, np.snapshotDir)
+	}
+
 	np.state = NixPatchStateApplied
+	log.Printf("[patch-%s] Nix patch applied successfully", np.id)
 
 	return nil
 }
 
-func (np *NixPatch) Cancel() error {
+func (np *nixPatch) Cancel() error {
 	if np.state != NixPatchStatePending {
 		return errors.New("patch already applied or cancelled")
 	}
@@ -101,7 +145,7 @@ func (np *NixPatch) Cancel() error {
 	return nil
 }
 
-func (np *NixPatch) snapshot() error {
+func (np *nixPatch) snapshot() error {
 	timestamp := time.Now().Unix()
 
 	snapshotDir := filepath.Join(np.nm.config.TmpDir, fmt.Sprintf("nix-patch-%d", timestamp))
@@ -112,15 +156,21 @@ func (np *NixPatch) snapshot() error {
 		return fmt.Errorf("failed to create snapshot directory: %w", err)
 	}
 
+	log.Printf("[patch-%s] Snapshotting nix directory to %s", np.id, snapshotDir)
+
 	np.snapshotDir = snapshotDir
-	return np.copyDirectory(np.nm.config.NixDir, np.snapshotDir)
+	return copyDirectory(np.nm.config.NixDir, np.snapshotDir)
 }
 
-func (np *NixPatch) triggerRollback(err error) error {
+func (np *nixPatch) triggerRollback(err error) error {
+	log.Printf("[patch-%s] Triggering rollback", np.id)
+	log.Printf("[patch-%s] Rollback triggered because of error: %v", np.id, err)
+
 	np.state = NixPatchStateRollingBack
 	np.error = err
 
 	if err := np.doRollback(); err != nil {
+		log.Printf("[patch-%s] Failed to actually roll back: %v", np.id, err)
 		return fmt.Errorf("failed to actually roll back: %w", err)
 	}
 
@@ -128,7 +178,7 @@ func (np *NixPatch) triggerRollback(err error) error {
 	return err
 }
 
-func (np *NixPatch) doRollback() error {
+func (np *nixPatch) doRollback() error {
 	if np.state != NixPatchStateApplying {
 		return nil
 	}
@@ -140,10 +190,90 @@ func (np *NixPatch) doRollback() error {
 		return fmt.Errorf("failed to remove nixDir: %w", err)
 	}
 
-	return np.copyDirectory(np.snapshotDir, np.nm.config.NixDir)
+	return copyDirectory(np.snapshotDir, np.nm.config.NixDir)
 }
 
-func (np *NixPatch) copyDirectory(srcDir, destDir string) error {
+func (np *nixPatch) UpdateSystemContainerConfiguration(values dogeboxd.NixSystemContainerConfigTemplateValues) {
+	np.add("UpdateSystemContainerConfiguration", func() error {
+		return np.writeTemplate("system_container_config.nix", rawSystemContainerConfigTemplate, values)
+	})
+}
+
+func (np *nixPatch) UpdateFirewall(values dogeboxd.NixFirewallTemplateValues) {
+	np.add("UpdateFirewall", func() error {
+		return np.writeTemplate("firewall.nix", rawFirewallTemplate, values)
+	})
+}
+
+func (np *nixPatch) UpdateSystem(values dogeboxd.NixSystemTemplateValues) {
+	np.add("UpdateSystem", func() error {
+		return np.writeTemplate("system.nix", rawSystemTemplate, values)
+	})
+}
+
+func (np *nixPatch) UpdateNetwork(values dogeboxd.NixNetworkTemplateValues) {
+	np.add("UpdateNetwork", func() error {
+		return np.writeTemplate("network.nix", rawNetworkTemplate, values)
+	})
+}
+
+func (np *nixPatch) UpdateIncludesFile(values dogeboxd.NixIncludesFileTemplateValues) {
+	np.add("UpdateIncludesFile", func() error {
+		return np.writeTemplate("dogebox.nix", rawIncludesFileTemplate, values)
+	})
+}
+
+func (np *nixPatch) WritePupFile(pupId string, values dogeboxd.NixPupContainerTemplateValues) {
+	np.add("WritePupFile", func() error {
+		filename := fmt.Sprintf("pup_%s.nix", pupId)
+		return np.writeTemplate(filename, rawPupContainerTemplate, values)
+	})
+}
+
+func (np *nixPatch) writeTemplate(filename string, _template []byte, values interface{}) error {
+	template, err := template.New(filename).Parse(string(_template))
+	if err != nil {
+		return err
+	}
+
+	var contents bytes.Buffer
+	err = template.Execute(&contents, values)
+	if err != nil {
+		return err
+	}
+
+	err = np.writeDogeboxNixFile(filename, contents.String())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (np *nixPatch) RemovePupFile(pupId string) {
+	np.add("RemovePupFile", func() error {
+		// Remove pup nix file
+		filename := fmt.Sprintf("pup_%s.nix", pupId)
+		return os.Remove(filepath.Join(np.nm.config.NixDir, filename))
+	})
+}
+
+func (np *nixPatch) writeDogeboxNixFile(filename string, content string) error {
+	fullPath := filepath.Join(np.nm.config.NixDir, filename)
+
+	err := os.MkdirAll(filepath.Dir(fullPath), 0755)
+	if err != nil {
+		return fmt.Errorf("failed to create directories for %s: %w", fullPath, err)
+	}
+	err = os.WriteFile(fullPath, []byte(content), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write file %s: %w", fullPath, err)
+	}
+
+	return nil
+}
+
+func copyDirectory(srcDir, destDir string) error {
 	err := filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err

--- a/pkg/system/nix/nix.go
+++ b/pkg/system/nix/nix.go
@@ -14,24 +14,6 @@ import (
 	"github.com/dogeorg/dogeboxd/pkg/pup"
 )
 
-//go:embed templates/pup_container.nix
-var rawPupContainerTemplate []byte
-
-//go:embed templates/system_container_config.nix
-var rawSystemContainerConfigTemplate []byte
-
-//go:embed templates/firewall.nix
-var rawFirewallTemplate []byte
-
-//go:embed templates/system.nix
-var rawSystemTemplate []byte
-
-//go:embed templates/dogebox.nix
-var rawIncludesFileTemplate []byte
-
-//go:embed templates/network.nix
-var rawNetworkTemplate []byte
-
 var _ dogeboxd.NixManager = &nixManager{}
 
 type nixManager struct {
@@ -382,6 +364,13 @@ func (nm nixManager) Rebuild() error {
 		log.Printf("nix output: %s\n", string(output))
 	}
 	return nil
+}
+
+func (nm nixManager) NewPatch() NixPatch {
+	return NixPatch{
+		nm:    nm,
+		state: NixPatchStatePending,
+	}
 }
 
 func toEnv(entries map[string]string) []dogeboxd.EnvEntry {

--- a/pkg/web/network.go
+++ b/pkg/web/network.go
@@ -17,12 +17,20 @@ func (t api) getNetwork(w http.ResponseWriter, r *http.Request) {
 }
 
 func (t api) connectNetwork(w http.ResponseWriter, r *http.Request) {
-	err := t.dbx.NetworkManager.TryConnect()
+	nixPatch := t.nix.NewPatch()
+
+	err := t.dbx.NetworkManager.TryConnect(nixPatch)
 	// Chances are we'll never actually get here, because you'll probably be disconnected
 	// from the box once (if) it changes networks, and your connection will break.
 	if err != nil {
 		log.Printf("Failed to connect to network: %+v", err)
 		sendErrorResponse(w, http.StatusInternalServerError, "Failed to connect to network")
+		return
+	}
+
+	if err := nixPatch.Apply(); err != nil {
+		log.Printf("Failed to apply nix patch: %+v", err)
+		sendErrorResponse(w, http.StatusInternalServerError, "Failed to apply nix patch")
 		return
 	}
 

--- a/pkg/web/setup.go
+++ b/pkg/web/setup.go
@@ -87,14 +87,18 @@ func (t api) initialBootstrap(w http.ResponseWriter, r *http.Request) {
 
 	// TODO: turn off AP
 
+	nixPatch := t.nix.NewPatch()
+
 	// This will try and connect to the pending network, and if
 	// that works, it will persist the network config to disk properly.
-	if err := t.dbx.NetworkManager.TryConnect(); err != nil {
+	if err := t.dbx.NetworkManager.TryConnect(nixPatch); err != nil {
+		log.Printf("Error connecting to network: %v", err)
 		sendErrorResponse(w, http.StatusInternalServerError, "Error connecting to network")
 		return
 	}
+	t.nix.InitSystem(nixPatch)
 
-	if err := t.nix.InitSystem(); err != nil {
+	if err := nixPatch.Apply(); err != nil {
 		sendErrorResponse(w, http.StatusInternalServerError, "Error initialising system")
 		return
 	}

--- a/pkg/web/setup.go
+++ b/pkg/web/setup.go
@@ -98,7 +98,9 @@ func (t api) initialBootstrap(w http.ResponseWriter, r *http.Request) {
 	}
 	t.nix.InitSystem(nixPatch)
 
-	if err := nixPatch.Apply(); err != nil {
+	if err := nixPatch.ApplyCustom(dogeboxd.NixPatchApplyOptions{
+		RebuildBoot: true,
+	}); err != nil {
 		sendErrorResponse(w, http.StatusInternalServerError, "Error initialising system")
 		return
 	}
@@ -135,12 +137,6 @@ func (t api) initialBootstrap(w http.ResponseWriter, r *http.Request) {
 	}
 
 	flusher.Flush()
-
-	if err := t.nix.RebuildBoot(); err != nil {
-		log.Printf("Error rebuilding nix: %v", err)
-		log.Println("Unfortunately we're going to have to reboot now, and there's no way we can report this to the client.")
-		// TODO: Maybe we write a file that gets shown to the user on next boot in dpanel?
-	}
 
 	log.Println("Dogebox successfully bootstrapped, rebooting so we can boot into normal mode.")
 


### PR DESCRIPTION
This adds the concept of `nix patches`, which are an atomic-ly applied changeset to dogeboxd nix configuration files.

We snapshot your specified `nixDir` before making any changes, and if a rebuild fails, we trigger a rollback and replace everything with the known-working configuration.


```go
patch := nix.NewPatch()

patch.DoUpdate1() // Queued, but not executed
patch.DoUpdate2() // Queued, but not executed

// Queued operations are applied one by one, in order.
// And then a nixos-rebuild is triggered.
err := patch.Apply()

if err != nil {
  // Failed, already rolled back, ready to clean up any other business logic you need to outside of nix
}
```