### PR TITLE
SSH Key management

### DIFF
--- a/cmd/dogeboxd/server.go
+++ b/cmd/dogeboxd/server.go
@@ -46,7 +46,7 @@ func (t server) Start() {
 	networkManager := network.NewNetworkManager(nixManager, t.sm)
 	lifecycleManager := lifecycle.NewLifecycleManager(t.config)
 
-	systemUpdater := system.NewSystemUpdater(t.config, networkManager, nixManager, sourceManager, pups)
+	systemUpdater := system.NewSystemUpdater(t.config, networkManager, nixManager, sourceManager, pups, t.sm)
 	journalReader := system.NewJournalReader(t.config)
 	logtailer := system.NewLogTailer(t.config)
 

--- a/pkg/dogeboxd.go
+++ b/pkg/dogeboxd.go
@@ -270,6 +270,18 @@ func (t Dogeboxd) jobDispatcher(j Job) {
 	case UpdatePendingSystemNetwork:
 		t.enqueue(j)
 
+	case EnableSSH:
+		t.enqueue(j)
+
+	case DisableSSH:
+		t.enqueue(j)
+
+	case AddSSHKey:
+		t.enqueue(j)
+
+	case RemoveSSHKey:
+		t.enqueue(j)
+
 	// Pup router actions
 	case UpdateMetrics:
 		t.Pups.UpdateMetrics(a)
@@ -358,9 +370,11 @@ func (t *Dogeboxd) updatePupProviders(j Job, u UpdatePupProviders) {
 
 	// If the pup may now start, update all of our nix files and rebuild.
 	if canPupStart {
+		dbxState := t.sm.Get().Dogebox
+
 		nixPatch := t.nix.NewPatch()
 		t.nix.UpdateSystemContainerConfiguration(nixPatch)
-		t.nix.WritePupFile(nixPatch, pupState)
+		t.nix.WritePupFile(nixPatch, pupState, dbxState)
 
 		if err := nixPatch.Apply(); err != nil {
 			fmt.Println("Failed to apply nix patch:", err)

--- a/pkg/events.go
+++ b/pkg/events.go
@@ -89,6 +89,17 @@ type UpdatePendingSystemNetwork struct {
 	Network SelectedNetwork
 }
 
+type EnableSSH struct{}
+type DisableSSH struct{}
+
+type AddSSHKey struct {
+	Key string
+}
+
+type RemoveSSHKey struct {
+	ID string
+}
+
 /* Updates are responses to Actions or simply
 * internal state changes that the frontend needs,
 * these are wrapped in a 'change' and sent via

--- a/pkg/system/nix/templates/system.nix
+++ b/pkg/system/nix/templates/system.nix
@@ -28,7 +28,7 @@
     openssh = {
       authorizedKeys = {
         keys = [
-          {{ range .SSH_KEYS }}"{{.}}"{{ end }}
+          {{ range .SSH_KEYS }}"{{.Key}} # {{.ID}}"{{ end }}
         ];
       };
     };

--- a/pkg/system/ssh.go
+++ b/pkg/system/ssh.go
@@ -1,0 +1,98 @@
+package system
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"log"
+
+	dogeboxd "github.com/dogeorg/dogeboxd/pkg"
+)
+
+func (t SystemUpdater) sshUpdate(dbxState dogeboxd.DogeboxState) error {
+	patch := t.nix.NewPatch()
+	t.nix.UpdateFirewallRules(patch, dbxState)
+	t.nix.UpdateSystem(patch, dogeboxd.NixSystemTemplateValues{
+		SYSTEM_HOSTNAME: dbxState.Hostname,
+		SSH_ENABLED:     dbxState.SSH.Enabled,
+		SSH_KEYS:        dbxState.SSH.Keys,
+	})
+
+	if err := patch.Apply(); err != nil {
+		log.Println("Failed to enable SSH:", err)
+		return err
+	}
+
+	return nil
+}
+
+func (t SystemUpdater) EnableSSH() error {
+	state := t.sm.Get().Dogebox
+	state.SSH.Enabled = true
+	t.sm.SetDogebox(state)
+	if err := t.sm.Save(); err != nil {
+		return err
+	}
+
+	return t.sshUpdate(state)
+}
+
+func (t SystemUpdater) DisableSSH() error {
+	state := t.sm.Get().Dogebox
+	state.SSH.Enabled = false
+	t.sm.SetDogebox(state)
+	if err := t.sm.Save(); err != nil {
+		return err
+	}
+
+	return t.sshUpdate(state)
+}
+
+func (t SystemUpdater) ListSSHKeys() ([]dogeboxd.DogeboxStateSSHKey, error) {
+	state := t.sm.Get().Dogebox
+	return state.SSH.Keys, nil
+}
+
+func (t SystemUpdater) AddSSHKey(key string) error {
+	state := t.sm.Get().Dogebox
+
+	keyID := make([]byte, 8)
+	if _, err := rand.Read(keyID); err != nil {
+		return fmt.Errorf("failed to generate random key ID: %v", err)
+	}
+
+	state.SSH.Keys = append(state.SSH.Keys, dogeboxd.DogeboxStateSSHKey{
+		ID:  hex.EncodeToString(keyID),
+		Key: key,
+	})
+
+	t.sm.SetDogebox(state)
+	if err := t.sm.Save(); err != nil {
+		return err
+	}
+
+	return t.sshUpdate(state)
+}
+func (t SystemUpdater) RemoveSSHKey(id string) error {
+	state := t.sm.Get().Dogebox
+
+	keyFound := false
+	for i, key := range state.SSH.Keys {
+		if key.ID == id {
+			state.SSH.Keys = append(state.SSH.Keys[:i], state.SSH.Keys[i+1:]...)
+			keyFound = true
+			break
+		}
+	}
+
+	if !keyFound {
+		return fmt.Errorf("SSH key with ID %s not found", id)
+	}
+
+	t.sm.SetDogebox(state)
+	if err := t.sm.Save(); err != nil {
+		return err
+	}
+
+	return t.sshUpdate(state)
+}

--- a/pkg/web/rest.go
+++ b/pkg/web/rest.go
@@ -71,6 +71,11 @@ func RESTAPI(
 		"POST /keys/create-master":        a.createMasterKey,
 		"GET /keys":                       a.listKeys,
 		"POST /system/bootstrap":          a.initialBootstrap,
+
+		"PUT /system/ssh/state":       a.setSSHState,
+		"GET /system/ssh/keys":        a.listSSHKeys,
+		"PUT /system/ssh/key":         a.addSSHKey,
+		"DELETE /system/ssh/key/{id}": a.removeSSHKey,
 	}
 
 	// Normal routes are used when we are not in recovery mode.

--- a/pkg/web/ssh.go
+++ b/pkg/web/ssh.go
@@ -1,0 +1,84 @@
+package web
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	dogeboxd "github.com/dogeorg/dogeboxd/pkg"
+)
+
+type SetSSHStateRequest struct {
+	Enabled string `json:"enabled"`
+}
+
+type AddSSHKeyRequest struct {
+	Key string `json:"key"`
+}
+
+func (t api) setSSHState(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		sendErrorResponse(w, http.StatusBadRequest, "Error reading request body")
+		return
+	}
+
+	var req SetSSHStateRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		sendErrorResponse(w, http.StatusBadRequest, "Error unmarshalling JSON")
+		return
+	}
+
+	var action dogeboxd.Action
+	if req.Enabled == "true" {
+		action = dogeboxd.EnableSSH{}
+	} else {
+		action = dogeboxd.DisableSSH{}
+	}
+
+	id := t.dbx.AddAction(action)
+	sendResponse(w, map[string]string{"id": id})
+}
+
+func (t api) listSSHKeys(w http.ResponseWriter, r *http.Request) {
+	keys, err := t.dbx.SystemUpdater.ListSSHKeys()
+	if err != nil {
+		sendErrorResponse(w, http.StatusInternalServerError, "Error listing SSH keys")
+		return
+	}
+
+	sendResponse(w, map[string]any{"keys": keys})
+}
+
+func (t api) addSSHKey(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		sendErrorResponse(w, http.StatusBadRequest, "Error reading request body")
+		return
+	}
+
+	var req AddSSHKeyRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		sendErrorResponse(w, http.StatusBadRequest, "Error unmarshalling JSON")
+		return
+	}
+
+	if req.Key == "" {
+		sendErrorResponse(w, http.StatusBadRequest, "SSH key is required")
+		return
+	}
+
+	id := t.dbx.AddAction(dogeboxd.AddSSHKey{Key: req.Key})
+	sendResponse(w, map[string]string{"id": id})
+}
+
+func (t api) removeSSHKey(w http.ResponseWriter, r *http.Request) {
+	keyId := r.PathValue("id")
+	if keyId == "" {
+		sendErrorResponse(w, http.StatusBadRequest, "Key ID is required")
+		return
+	}
+
+	id := t.dbx.AddAction(dogeboxd.RemoveSSHKey{ID: keyId})
+	sendResponse(w, map[string]string{"id": id})
+}


### PR DESCRIPTION
This provides management for SSH server & key management for physical hardware that don't have TTY-accessible consoles for getting shell access.

Also we persist the hostname chosen by the user now instead of hardcoding it to `dogebox`.