### PR TITLE
Allow pups to define nix services to start

### DIFF
--- a/pkg/pup/manifest.go
+++ b/pkg/pup/manifest.go
@@ -40,10 +40,6 @@ func (m *PupManifest) Validate() error {
 		return fmt.Errorf("manifest container.build.nixFileSha256 is required")
 	}
 
-	if len(m.Container.Services) == 0 {
-		return fmt.Errorf("at least one service is required")
-	}
-
 	for _, service := range m.Container.Services {
 		if service.Name == "" {
 			return fmt.Errorf("service name is required")


### PR DESCRIPTION
This is necessary so that pups can use pre-packaged, managed, nix `services.<blah>` configuration inside their containers, instead of having to manually rebuild things that community has already done.

A pup can now explicitly export a `services` directive block that gets merged into the containers services block.

eg:

Running mysql & caddy:

_pup.nix_
```nix
{ pkgs }:

let
  files = pkgs.stdenv.mkDerivation {
    name = "files";
    src = ./.;
    installPhase = ''
      mkdir -p $out/opt/www
      cp -r . $out/opt/www
    '';
  };

  services = {
    mysql = {
      enable = true;
      package = pkgs.mysql;
    };

    caddy = {
      enable = true;
      package = pkgs.caddy;
      extraConfig = ''
        :8090 {
          root * ${files}/opt/www
          handle_errors {
            respond "404"
          }
        }
      '';
    };
  };
in
{
  inherit services;
}
```