### PR TITLE
Allow the user to specify an initial SSH key at setup

### DIFF
--- a/pkg/sys.go
+++ b/pkg/sys.go
@@ -15,6 +15,10 @@ type SystemUpdater interface {
 	AddJob(Job)
 	GetUpdateChannel() chan Job
 
+	// These ideally should not be on here, but we currently don't
+	// have a way to wait for a SystemUpdater event to finish.
+	AddSSHKey(key string) error
+	EnableSSH() error
 	ListSSHKeys() ([]DogeboxStateSSHKey, error)
 }
 

--- a/pkg/system/nix/templates/system.nix
+++ b/pkg/system/nix/templates/system.nix
@@ -20,7 +20,7 @@
 +===================================================+
 '';
 
-  services.openssh.enable = {{ .SSH_ENABLED }};
+  services.openssh.enable = lib.mkForce {{ .SSH_ENABLED }};
 
   users.users.shibe = {
     isNormalUser = true;


### PR DESCRIPTION
Workaround for people so they can access their physical hardware without a proper management UI built. dpanel changes incoming.