### PR TITLE
Properly handle half-installed & broken pups

### DIFF
--- a/pkg/pup_manager.go
+++ b/pkg/pup_manager.go
@@ -974,6 +974,12 @@ func SetPupInstallation(state string) func(*PupState, *[]Pupdate) {
 	}
 }
 
+func SetPupBrokenReason(reason string) func(*PupState, *[]Pupdate) {
+	return func(p *PupState, pu *[]Pupdate) {
+		p.BrokenReason = reason
+	}
+}
+
 func SetPupConfig(newFields map[string]string) func(*PupState, *[]Pupdate) {
 	return func(p *PupState, pu *[]Pupdate) {
 		for k, v := range newFields {

--- a/pkg/pups.go
+++ b/pkg/pups.go
@@ -20,6 +20,18 @@ const (
 	STATE_STOPPING     string = "stopping"
 )
 
+const (
+	BROKEN_REASON_STATE_UPDATE_FAILED          string = "state_update_failed"
+	BROKEN_REASON_DOWNLOAD_FAILED              string = "download_failed"
+	BROKEN_REASON_NIX_FILE_MISSING             string = "nix_file_missing"
+	BROKEN_REASON_NIX_HASH_MISMATCH            string = "nix_hash_mismatch"
+	BROKEN_REASON_STORAGE_CREATION_FAILED      string = "storage_creation_failed"
+	BROKEN_REASON_DELEGATE_KEY_CREATION_FAILED string = "delegate_key_creation_failed"
+	BROKEN_REASON_DELEGATE_KEY_WRITE_FAILED    string = "delegate_key_write_failed"
+	BROKEN_REASON_ENABLE_FAILED                string = "enable_failed"
+	BROKEN_REASON_NIX_APPLY_FAILED             string = "nix_apply_failed"
+)
+
 /* Pup state vs pup stats
  * ┌─────────────────────────────┬───────────────────────────────┐
  * │PupState.Installation        │ PupStats.Status               │
@@ -46,6 +58,7 @@ type PupState struct {
 	Providers    map[string]string           `json:"providers"`    // providers of interface dependencies
 	Hooks        []PupHook                   `json:"hooks"`        // webhooks
 	Installation string                      `json:"installation"` // see table above and constants
+	BrokenReason string                      `json:"brokenReason"` // reason for being in a broken state
 	Enabled      bool                        `json:"enabled"`      // Is this pup supposed to be running?
 	NeedsConf    bool                        `json:"needsConf"`    // Has all required config been provided?
 	NeedsDeps    bool                        `json:"needsDeps"`    // Have all dependencies been met?

--- a/pkg/system/nix/nix-patch.go
+++ b/pkg/system/nix/nix-patch.go
@@ -266,7 +266,12 @@ func (np *nixPatch) RemovePupFile(pupId string) {
 	np.add("RemovePupFile", func() error {
 		// Remove pup nix file
 		filename := fmt.Sprintf("pup_%s.nix", pupId)
-		return os.Remove(filepath.Join(np.nm.config.NixDir, filename))
+		if _, err := os.Stat(filepath.Join(np.nm.config.NixDir, filename)); err == nil {
+			if err := os.Remove(filepath.Join(np.nm.config.NixDir, filename)); err != nil {
+				return fmt.Errorf("failed to remove file %s: %w", filename, err)
+			}
+		}
+		return nil
 	})
 }
 


### PR DESCRIPTION
This sets pups to `broken` and stores an error code on the state that can be used to convey information the client.

