### PR TITLE
Submit info to reflector at boot instead of before reboot

### DIFF
--- a/cmd/dogeboxd/server.go
+++ b/cmd/dogeboxd/server.go
@@ -61,6 +61,16 @@ func (t server) Start() {
 		fmt.Printf("pups %s:\n %+v\n", k, p)
 	}
 
+	// Check if we have pending reflector data to submit.
+	localIP, err := networkManager.GetLocalIP()
+	if err != nil {
+		log.Printf("Error getting local IP: %v", err)
+	} else {
+		if err := system.CheckAndSubmitReflectorData(t.config, localIP.String()); err != nil {
+			log.Printf("Error checking and submitting reflector data: %v", err)
+		}
+	}
+
 	/* ----------------------------------------------------------------------- */
 	// Set up Dogeboxd, the beating heart of the beast
 

--- a/cmd/dogeboxd/server.go
+++ b/cmd/dogeboxd/server.go
@@ -62,13 +62,8 @@ func (t server) Start() {
 	}
 
 	// Check if we have pending reflector data to submit.
-	localIP, err := networkManager.GetLocalIP()
-	if err != nil {
-		log.Printf("Error getting local IP: %v", err)
-	} else {
-		if err := system.CheckAndSubmitReflectorData(t.config, localIP.String()); err != nil {
-			log.Printf("Error checking and submitting reflector data: %v", err)
-		}
+	if err := system.CheckAndSubmitReflectorData(t.config, networkManager); err != nil {
+		log.Printf("Error checking and submitting reflector data: %v", err)
 	}
 
 	/* ----------------------------------------------------------------------- */

--- a/pkg/system/reflector.go
+++ b/pkg/system/reflector.go
@@ -1,19 +1,72 @@
 package system
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
+	"os"
+	"path/filepath"
 
 	dogeboxd "github.com/dogeorg/dogeboxd/pkg"
 	"github.com/go-resty/resty/v2"
 )
 
-func SubmitToReflector(config dogeboxd.ServerConfig, host, token, localIP string) error {
+type ReflectorFileData struct {
+	Host  string `json:"host"`
+	Token string `json:"token"`
+}
+
+func SaveReflectorTokenForReboot(config dogeboxd.ServerConfig, host, token string) error {
+	data := ReflectorFileData{
+		Host:  host,
+		Token: token,
+	}
+
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal reflector data: %w", err)
+	}
+
+	filePath := filepath.Join(config.DataDir, "reflector.json")
+	err = os.WriteFile(filePath, jsonData, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write reflector data: %w", err)
+	}
+
+	return nil
+}
+
+func CheckAndSubmitReflectorData(config dogeboxd.ServerConfig, localIP string) error {
 	if config.DisableReflector {
-		log.Println("Reflector disabled, skipping submission")
+		log.Println("Reflector disabled, skipping checking")
 		return nil
 	}
+
+	filePath := filepath.Join(config.DataDir, "reflector.json")
+	jsonData, err := os.ReadFile(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to read reflector data file: %w", err)
+	}
+
+	var data ReflectorFileData
+	if err := json.Unmarshal(jsonData, &data); err != nil {
+		log.Println("invalid reflector data: host or token is empty")
+		return nil
+	}
+
+	host := data.Host
+	token := data.Token
+
+	if host == "" || token == "" {
+		log.Println("invalid reflector data: host or token is empty")
+		return nil
+	}
+
+	log.Printf("Submitting reflector data to %s w/ token %s", host, token)
 
 	client := resty.New()
 	client.SetBaseURL(host)
@@ -25,10 +78,12 @@ func SubmitToReflector(config dogeboxd.ServerConfig, host, token, localIP string
 		Post("/")
 
 	if err != nil {
+		log.Printf("Failed to submit to reflector: %s", err)
 		return err
 	}
 
 	if resp.StatusCode() != http.StatusCreated {
+		log.Printf("Failed to submit to reflector: %s", resp.String())
 		return fmt.Errorf("failed to submit to reflector: %s", resp.String())
 	}
 

--- a/pkg/web/setup.go
+++ b/pkg/web/setup.go
@@ -120,17 +120,8 @@ func (t api) initialBootstrap(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if requestBody.ReflectorToken != "" && requestBody.ReflectorHost != "" {
-		localIP, err := t.dbx.NetworkManager.GetLocalIP()
-		if err != nil {
-			log.Printf("Error getting local IP: %v", err)
-			sendErrorResponse(w, http.StatusInternalServerError, "Error getting local IP")
-			return
-		}
-
-		if err := system.SubmitToReflector(t.config, requestBody.ReflectorHost, requestBody.ReflectorToken, localIP.String()); err != nil {
-			log.Printf("Error submitting to reflector: %v", err)
-			sendErrorResponse(w, http.StatusInternalServerError, "Error submitting to reflector")
-			return
+		if err := system.SaveReflectorTokenForReboot(t.config, requestBody.ReflectorHost, requestBody.ReflectorToken); err != nil {
+			log.Printf("Error saving reflector data: %v", err)
 		}
 	}
 


### PR DESCRIPTION
This is probably the behaviour of what we actually want, as there is a small potential for the machine to be given a different IP address when it comes back online after being rebooted.