### PR TITLE
Only import pup files if they exist

### DIFF
--- a/pkg/system/nix/templates/dogebox.nix
+++ b/pkg/system/nix/templates/dogebox.nix
@@ -7,7 +7,8 @@
     ./network.nix
     # ./recovery_ap.nix
     ./system_container_config.nix
-    {{range .PUP_IDS}}./pup_{{.}}.nix
-    {{end}}
-  ];
+  ]
+  {{range .PUP_IDS}}++ lib.optionals (builtins.pathExists ./pup_{{.}}.nix) [ ./pup_{{.}}.nix ]
+  {{end}}
+  ;
 }


### PR DESCRIPTION
This should prevent an issue where somebody wipes their `$data/nix/pup_` files and then tries to rebuild..  