### PR TITLE
Add APIs for System Installation

### DIFF
--- a/cmd/_dbxroot/cmd/install-to-disk.go
+++ b/cmd/_dbxroot/cmd/install-to-disk.go
@@ -78,6 +78,10 @@ Example:
 		// Generate hardware-configuration.nix
 		runCommand("nixos-generate-config", "--root", "/mnt")
 
+		// Set an installed flag so we know not to try again.
+		runCommand("mkdir", "-p", "/mnt/opt/")
+		runCommand("touch", "/mnt/opt/dbx-installed")
+
 		// Install
 		runCommand("nixos-install", "--no-root-passwd", "--root", "/mnt")
 

--- a/cmd/dbx/cmd/get-disks.go
+++ b/cmd/dbx/cmd/get-disks.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	_ "embed"
-	"fmt"
 	"log"
 	"os"
 
@@ -23,8 +22,7 @@ var getDisksCmd = &cobra.Command{
 		log.Println("Possible install disks:")
 
 		for _, disk := range disks {
-			size := prettyPrintDiskSize(disk.Size.Int64)
-			log.Printf(" - %s (%s)", disk.Name, size)
+			log.Printf(" - %s (%s)", disk.Name, disk.SizePretty)
 		}
 
 		os.Exit(0)
@@ -33,26 +31,4 @@ var getDisksCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(getDisksCmd)
-}
-
-func prettyPrintDiskSize(size int64) string {
-	const (
-		KB = 1024
-		MB = 1024 * KB
-		GB = 1024 * MB
-		TB = 1024 * GB
-	)
-
-	switch {
-	case size >= TB:
-		return fmt.Sprintf("%.2f TB", float64(size)/float64(TB))
-	case size >= GB:
-		return fmt.Sprintf("%.2f GB", float64(size)/float64(GB))
-	case size >= MB:
-		return fmt.Sprintf("%.2f MB", float64(size)/float64(MB))
-	case size >= KB:
-		return fmt.Sprintf("%.2f KB", float64(size)/float64(KB))
-	default:
-		return fmt.Sprintf("%d B", size)
-	}
 }

--- a/cmd/dbx/cmd/get-install-disks.go
+++ b/cmd/dbx/cmd/get-install-disks.go
@@ -10,18 +10,27 @@ import (
 )
 
 var getDisksCmd = &cobra.Command{
-	Use:   "get-disks",
-	Short: "Get a list of possible install disks.",
+	Use:   "get-install-disks",
+	Short: "Get a list of suitable disks you can install DogeboxOS to.",
 	Run: func(cmd *cobra.Command, args []string) {
-		disks, err := system.GetPossibleInstallDisks()
+		disks, err := system.GetSystemDisks()
 		if err != nil {
-			log.Printf("Failed to get possible install disks: %+v", err)
+			log.Printf("Failed to get list of disks: %+v", err)
 			os.Exit(1)
 		}
 
-		log.Println("Possible install disks:")
+		if len(disks) == 0 {
+			log.Println("No suitable install disks found.")
+			os.Exit(1)
+		}
+
+		log.Println("Suitable install disks:")
 
 		for _, disk := range disks {
+			if !disk.SuitableInstallDrive {
+				continue
+			}
+
 			log.Printf(" - %s (%s)", disk.Name, disk.SizePretty)
 		}
 

--- a/pkg/sys.go
+++ b/pkg/sys.go
@@ -332,15 +332,20 @@ type NixManager interface {
 	NewPatch(log SubLogger) NixPatch
 }
 
-type PossibleInstallDisk struct {
-	Name       string `json:"name"`
-	Size       int64  `json:"size"`
-	SizePretty string `json:"sizePretty"`
+type SystemDisk struct {
+	Name                 string `json:"name"`
+	Size                 int64  `json:"size"`
+	SizePretty           string `json:"sizePretty"`
+	SuitableInstallDrive bool   `json:"suitableInstallDrive"`
+	SuitableDataDrive    bool   `json:"suitableDataDrive"`
+	BootMedia            bool   `json:"bootMedia"`
 }
 
+type BootstrapInstallationMode string
+
 const (
-	BootstrapInstallationModeIsInstalled   = "isInstalled"
-	BootstrapInstallationModeCanInstalled  = "canInstall"
-	BootstrapInstallationModeMustInstall   = "mustInstall"
-	BootstrapInstallationModeCannotInstall = "cannotInstall"
+	BootstrapInstallationModeIsInstalled   BootstrapInstallationMode = "isInstalled"
+	BootstrapInstallationModeCanInstalled  BootstrapInstallationMode = "canInstall"
+	BootstrapInstallationModeMustInstall   BootstrapInstallationMode = "mustInstall"
+	BootstrapInstallationModeCannotInstall BootstrapInstallationMode = "cannotInstall"
 )

--- a/pkg/sys.go
+++ b/pkg/sys.go
@@ -331,3 +331,16 @@ type NixManager interface {
 
 	NewPatch(log SubLogger) NixPatch
 }
+
+type PossibleInstallDisk struct {
+	Name       string
+	Size       int64
+	SizePretty string
+}
+
+const (
+	BootstrapInstallationModeIsInstalled   = "isInstalled"
+	BootstrapInstallationModeCanInstalled  = "canInstall"
+	BootstrapInstallationModeMustInstall   = "mustInstall"
+	BootstrapInstallationModeCannotInstall = "cannotInstall"
+)

--- a/pkg/sys.go
+++ b/pkg/sys.go
@@ -333,9 +333,9 @@ type NixManager interface {
 }
 
 type PossibleInstallDisk struct {
-	Name       string
-	Size       int64
-	SizePretty string
+	Name       string `json:"name"`
+	Size       int64  `json:"size"`
+	SizePretty string `json:"sizePretty"`
 }
 
 const (

--- a/pkg/system/installation.go
+++ b/pkg/system/installation.go
@@ -139,7 +139,7 @@ func InstallToDisk(config dogeboxd.ServerConfig, dbxState dogeboxd.DogeboxState,
 
 	log.Printf("Starting to install to disk %s", name)
 
-	cmd := exec.Command("_dbxroot", "install-to-disk", "--disk", name, "--dbx-secret", DBXRootSecret)
+	cmd := exec.Command("sudo", "_dbxroot", "install-to-disk", "--disk", name, "--dbx-secret", DBXRootSecret)
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -23,3 +23,25 @@ func ImageBytesToWebBase64(imgBytes []byte, filename string) (string, error) {
 
 	return "data:" + contentType + ";base64," + logoData64, nil
 }
+
+func PrettyPrintDiskSize(size int64) string {
+	const (
+		KB = 1024
+		MB = 1024 * KB
+		GB = 1024 * MB
+		TB = 1024 * GB
+	)
+
+	switch {
+	case size >= TB:
+		return fmt.Sprintf("%.2f TB", float64(size)/float64(TB))
+	case size >= GB:
+		return fmt.Sprintf("%.2f GB", float64(size)/float64(GB))
+	case size >= MB:
+		return fmt.Sprintf("%.2f MB", float64(size)/float64(MB))
+	case size >= KB:
+		return fmt.Sprintf("%.2f KB", float64(size)/float64(KB))
+	default:
+		return fmt.Sprintf("%d B", size)
+	}
+}

--- a/pkg/web/install.go
+++ b/pkg/web/install.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 
-	dogeboxd "github.com/dogeorg/dogeboxd/pkg"
 	"github.com/dogeorg/dogeboxd/pkg/system"
 )
 
@@ -14,7 +13,7 @@ type InstallToDiskRequest struct {
 }
 
 func (t api) getInstallDisks(w http.ResponseWriter, r *http.Request) {
-	disks, err := system.GetPossibleInstallDisks()
+	disks, err := system.GetSystemDisks()
 	if err != nil {
 		sendErrorResponse(w, http.StatusInternalServerError, err.Error())
 		return
@@ -47,18 +46,7 @@ func (t api) installToDisk(w http.ResponseWriter, r *http.Request) {
 
 	dbxState := t.sm.Get().Dogebox
 
-	mode, err := system.GetInstallationMode(dbxState)
-	if err != nil {
-		sendErrorResponse(w, http.StatusBadRequest, "Could not determine installation mode")
-		return
-	}
-
-	if mode != dogeboxd.BootstrapInstallationModeMustInstall && mode != dogeboxd.BootstrapInstallationModeCanInstalled {
-		// We're not in a state where we can actually install.
-		sendErrorResponse(w, http.StatusBadRequest, "Not in installable state")
-	}
-
-	if err := system.InstallToDisk(req.Disk); err != nil {
+	if err := system.InstallToDisk(t.config, dbxState, req.Disk); err != nil {
 		sendErrorResponse(w, http.StatusInternalServerError, "Error installing to disk: "+err.Error())
 		return
 	}

--- a/pkg/web/install.go
+++ b/pkg/web/install.go
@@ -1,0 +1,67 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+
+	dogeboxd "github.com/dogeorg/dogeboxd/pkg"
+	"github.com/dogeorg/dogeboxd/pkg/system"
+)
+
+type InstallToDiskRequest struct {
+	Disk   string `json:"disk"`
+	Secret string `json:"secret"`
+}
+
+func (t api) getInstallDisks(w http.ResponseWriter, r *http.Request) {
+	disks, err := system.GetPossibleInstallDisks()
+	if err != nil {
+		sendErrorResponse(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	sendResponse(w, disks)
+}
+
+func (t api) installToDisk(w http.ResponseWriter, r *http.Request) {
+	var req InstallToDiskRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		sendErrorResponse(w, http.StatusBadRequest, "Error unmarshalling JSON: "+err.Error())
+		return
+	}
+
+	if req.Disk == "" {
+		sendErrorResponse(w, http.StatusBadRequest, "Disk is required")
+		return
+	}
+
+	if req.Secret == "" {
+		sendErrorResponse(w, http.StatusBadRequest, "Secret is required")
+		return
+	}
+
+	if req.Secret != system.DBXRootSecret {
+		sendErrorResponse(w, http.StatusForbidden, "Invalid secret")
+		return
+	}
+
+	dbxState := t.sm.Get().Dogebox
+
+	mode, err := system.GetInstallationMode(dbxState)
+	if err != nil {
+		sendErrorResponse(w, http.StatusBadRequest, "Could not determine installation mode")
+		return
+	}
+
+	if mode != dogeboxd.BootstrapInstallationModeMustInstall && mode != dogeboxd.BootstrapInstallationModeCanInstalled {
+		// We're not in a state where we can actually install.
+		sendErrorResponse(w, http.StatusBadRequest, "Not in installable state")
+	}
+
+	if err := system.InstallToDisk(req.Disk); err != nil {
+		sendErrorResponse(w, http.StatusInternalServerError, "Error installing to disk: "+err.Error())
+		return
+	}
+
+	sendResponse(w, map[string]string{"status": "ok"})
+}

--- a/pkg/web/rest.go
+++ b/pkg/web/rest.go
@@ -59,9 +59,13 @@ func RESTAPI(
 
 	// Recovery routes are the _only_ routes loaded in recovery mode.
 	recoveryRoutes := map[string]http.HandlerFunc{
-		"POST /authenticate":              a.authenticate,
-		"POST /logout":                    a.logout,
-		"GET /system/bootstrap":           a.getBootstrap,
+		"POST /authenticate":    a.authenticate,
+		"POST /logout":          a.logout,
+		"GET /system/bootstrap": a.getBootstrap,
+
+		"GET /system/install/disks": a.getInstallDisks,
+		"POST /system/install":      a.installToDisk,
+
 		"GET /system/network/list":        a.getNetwork,
 		"PUT /system/network/set-pending": a.setPendingNetwork,
 		"POST /system/network/connect":    a.connectNetwork,

--- a/pkg/web/rest.go
+++ b/pkg/web/rest.go
@@ -59,12 +59,12 @@ func RESTAPI(
 
 	// Recovery routes are the _only_ routes loaded in recovery mode.
 	recoveryRoutes := map[string]http.HandlerFunc{
-		"POST /authenticate":    a.authenticate,
-		"POST /logout":          a.logout,
-		"GET /system/bootstrap": a.getBootstrap,
+		"POST /authenticate": a.authenticate,
+		"POST /logout":       a.logout,
 
-		"GET /system/install/disks": a.getInstallDisks,
-		"POST /system/install":      a.installToDisk,
+		"GET /system/bootstrap": a.getBootstrap,
+		"GET /system/disks":     a.getInstallDisks,
+		"POST /system/install":  a.installToDisk,
 
 		"GET /system/network/list":        a.getNetwork,
 		"PUT /system/network/set-pending": a.setPendingNetwork,

--- a/pkg/web/session.go
+++ b/pkg/web/session.go
@@ -149,7 +149,7 @@ func authReq(dbx dogeboxd.Dogeboxd, sm dogeboxd.StateManager, route string, next
 	// TODO: Don't hardcode these.
 	if route == "GET /system/bootstrap" ||
 		route == "POST /system/bootstrap" ||
-		route == "GET /system/install/disks" ||
+		route == "GET /system/disks" ||
 		route == "POST /system/install" ||
 		route == "GET /system/network/list" ||
 		route == "PUT /system/network/set-pending" ||

--- a/pkg/web/session.go
+++ b/pkg/web/session.go
@@ -149,6 +149,8 @@ func authReq(dbx dogeboxd.Dogeboxd, sm dogeboxd.StateManager, route string, next
 	// TODO: Don't hardcode these.
 	if route == "GET /system/bootstrap" ||
 		route == "POST /system/bootstrap" ||
+		route == "GET /system/install/disks" ||
+		route == "POST /system/install" ||
 		route == "GET /system/network/list" ||
 		route == "PUT /system/network/set-pending" ||
 		route == "GET /keys" ||

--- a/pkg/web/setup.go
+++ b/pkg/web/setup.go
@@ -19,13 +19,14 @@ type InitialSystemBootstrapRequestBody struct {
 }
 
 type BootstrapFacts struct {
-	InstallationMode                 string `json:"installationMode"`
-	HasGeneratedKey                  bool   `json:"hasGeneratedKey"`
-	HasConfiguredNetwork             bool   `json:"hasConfiguredNetwork"`
-	HasCompletedInitialConfiguration bool   `json:"hasCompletedInitialConfiguration"`
+	InstallationMode                 dogeboxd.BootstrapInstallationMode `json:"installationMode"`
+	HasGeneratedKey                  bool                               `json:"hasGeneratedKey"`
+	HasConfiguredNetwork             bool                               `json:"hasConfiguredNetwork"`
+	HasCompletedInitialConfiguration bool                               `json:"hasCompletedInitialConfiguration"`
 }
 
 type BootstrapResponse struct {
+	DevMode    bool                         `json:"devMode"`
 	Assets     map[string]dogeboxd.PupAsset `json:"assets"`
 	States     map[string]dogeboxd.PupState `json:"states"`
 	Stats      map[string]dogeboxd.PupStats `json:"stats"`
@@ -42,9 +43,10 @@ func (t api) getRawBS() BootstrapResponse {
 	}
 
 	return BootstrapResponse{
-		Assets: t.pups.GetAssetsMap(),
-		States: t.pups.GetStateMap(),
-		Stats:  t.pups.GetStatsMap(),
+		DevMode: t.config.DevMode,
+		Assets:  t.pups.GetAssetsMap(),
+		States:  t.pups.GetStateMap(),
+		Stats:   t.pups.GetStatsMap(),
 		SetupFacts: BootstrapFacts{
 			InstallationMode:                 installationMode,
 			HasGeneratedKey:                  dbxState.InitialState.HasGeneratedKey,


### PR DESCRIPTION
This adds web APIs for system installation.

`GET /system/bootstrap` is modified to return a new `setupFact` named `installationMode`.

```json
{
    "assets": {},
    "states": {},
    "stats": {},
    "setupFacts": {
        "installationMode": "canInstall",
        ...
    }
}
```

There are 4 modes that can be returned:
  - `isInstalled`: This means that the box has already been installed.
  - `cannotInstall`: This occurs when the box has already been **set up**.
  - `mustInstall`: The user is booting off read-only media and MUST install to continue use.
  - `canInstall`: The user is booting off read-write media, and installation is optional to another disk.

A new `GET /system/install/disks` is added that returns a list of possible disk-installation targets:

```js
➜  http 127.0.0.1:3000/system/install/disks
[
    {
        "Name": "/dev/vdb",
        "Size": 8796093022208,
        "SizePretty": "8.00 TB"
    }
]
```

A new `POST /system/install` call is added that actually performs the system installation. It expects a body of:

```json
{
  "disk": "/dev/vdb",
  "secret": "yes-i-will-destroy-everything-on-this-disk"
}
```
