### PR TITLE
Expand disk usability information

### DIFF
--- a/cmd/dbx/cmd/get-install-disks.go
+++ b/cmd/dbx/cmd/get-install-disks.go
@@ -27,7 +27,7 @@ var getDisksCmd = &cobra.Command{
 		log.Println("Suitable install disks:")
 
 		for _, disk := range disks {
-			if !disk.SuitableInstallDrive {
+			if !disk.Suitability.Install.Usable {
 				continue
 			}
 

--- a/pkg/sys.go
+++ b/pkg/sys.go
@@ -345,13 +345,22 @@ type NixManager interface {
 	NewPatch(log SubLogger) NixPatch
 }
 
+type SystemDiskSuitabilityEntry struct {
+	Usable bool `json:"usable"`
+	SizeOK bool `json:"sizeOK"`
+}
+
+type SystemDiskSuitability struct {
+	Install SystemDiskSuitabilityEntry `json:"install"`
+	Storage SystemDiskSuitabilityEntry `json:"storage"`
+}
+
 type SystemDisk struct {
-	Name                 string `json:"name"`
-	Size                 int64  `json:"size"`
-	SizePretty           string `json:"sizePretty"`
-	SuitableInstallDrive bool   `json:"suitableInstallDrive"`
-	SuitableDataDrive    bool   `json:"suitableDataDrive"`
-	BootMedia            bool   `json:"bootMedia"`
+	Name        string                `json:"name"`
+	Size        int64                 `json:"size"`
+	SizePretty  string                `json:"sizePretty"`
+	Suitability SystemDiskSuitability `json:"suitability"`
+	BootMedia   bool                  `json:"bootMedia"`
 }
 
 type BootstrapInstallationMode string

--- a/pkg/web/setup.go
+++ b/pkg/web/setup.go
@@ -212,7 +212,7 @@ func (t api) setStorageDevice(w http.ResponseWriter, r *http.Request) {
 
 	// Ensure that the provided storage device can actually be used.
 	for _, disk := range disks {
-		if disk.Name == requestBody.StorageDevice {
+		if disk.Name == requestBody.StorageDevice && disk.Suitability.Storage.Usable {
 			foundDisk = &disk
 			break
 		}


### PR DESCRIPTION
This now returns:

```
{
  ..
  name: "/dev/sda",
  suitability: {
    install: {
      usable: true,
      sizeOK: true
    },
    storage: {
      usable: true,
      sizeOK: false
    }
   }
}
```

For disks, so the frontend knows if it should display a disk size warning or not.