### PR TITLE
Add release information to builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,22 @@ mkbuild:
 build: build/dogeboxd build/dbx build/_dbxroot
 
 build/dogeboxd: clean mkbuild
-	go build -o build/dogeboxd ./cmd/dogeboxd/.
+	go build \
+		-ldflags "-X version.dbxRelease=${DBX_RELEASE} -X version.nurHash=${DBX_NUR_HASH}" \
+		-o build/dogeboxd \
+			./cmd/dogeboxd/.
 
 build/dbx: clean mkbuild
-	go build -o build/dbx ./cmd/dbx/.
+	go build \
+		-ldflags "-X github.com/dogeorg/dogeboxd/pkg/version.dbxRelease=${DBX_RELEASE} -X github.com/dogeorg/dogeboxd/pkg/version.nurHash=${DBX_NUR_HASH}" \
+		-o build/dbx \
+		./cmd/dbx/.
 
 build/_dbxroot: clean mkbuild
-	go build -o build/_dbxroot ./cmd/_dbxroot/.
+	go build \
+		-ldflags "-X github.com/dogeorg/dogeboxd/pkg/version.dbxRelease=${DBX_RELEASE} -X github.com/dogeorg/dogeboxd/pkg/version.nurHash=${DBX_NUR_HASH}" \
+		-o build/_dbxroot \
+		./cmd/_dbxroot/.
 
 multipassdev:
 	go run ./cmd/dogeboxd -v -addr 0.0.0.0 -pups ~/

--- a/cmd/dbx/cmd/version.go
+++ b/cmd/dbx/cmd/version.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/dogeorg/dogeboxd/pkg/version"
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Get dogebox version information",
+	Run: func(cmd *cobra.Command, args []string) {
+		version := version.GetDBXRelease()
+
+		fmt.Printf("Release: %s\n", version.Release)
+		fmt.Printf("NurHash: %s\n", version.NurHash)
+		fmt.Printf("Git: %s\n", version.Git.Commit)
+		fmt.Printf("Dirty: %t\n", version.Git.Dirty)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/carlmjohnson/versioninfo v0.22.5 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
+github.com/carlmjohnson/versioninfo v0.22.5 h1:O00sjOLUAFxYQjlN/bzYTuZiS0y6fWDQjMRvwtKgwwc=
+github.com/carlmjohnson/versioninfo v0.22.5/go.mod h1:QT9mph3wcVfISUKd0i9sZfVrPviHuSF+cUtLjm2WSf8=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,45 @@
+package version
+
+import (
+	"github.com/carlmjohnson/versioninfo"
+)
+
+/* injected */
+
+var dbxRelease string
+var nurHash string
+
+/* ** */
+
+type DBXVersionInfoGit struct {
+	Commit string `json:"commit"`
+	Dirty  bool   `json:"dirty"`
+}
+
+type DBXVersionInfo struct {
+	Release string            `json:"release"`
+	NurHash string            `json:"nurHash"`
+	Git     DBXVersionInfoGit `json:"git"`
+}
+
+func GetDBXRelease() *DBXVersionInfo {
+	release := dbxRelease
+	nurHash := nurHash
+
+	if release == "" {
+		release = "unknown"
+	}
+
+	if nurHash == "" {
+		nurHash = "unknown"
+	}
+
+	return &DBXVersionInfo{
+		Release: release,
+		NurHash: nurHash,
+		Git: DBXVersionInfoGit{
+			Commit: versioninfo.Revision,
+			Dirty:  versioninfo.DirtyBuild,
+		},
+	}
+}

--- a/pkg/web/setup.go
+++ b/pkg/web/setup.go
@@ -11,6 +11,7 @@ import (
 	dogeboxd "github.com/dogeorg/dogeboxd/pkg"
 	"github.com/dogeorg/dogeboxd/pkg/system"
 	"github.com/dogeorg/dogeboxd/pkg/utils"
+	"github.com/dogeorg/dogeboxd/pkg/version"
 )
 
 type InitialSystemBootstrapRequestBody struct {
@@ -27,6 +28,7 @@ type BootstrapFacts struct {
 }
 
 type BootstrapResponse struct {
+	Version    *version.DBXVersionInfo      `json:"version"`
 	DevMode    bool                         `json:"devMode"`
 	Assets     map[string]dogeboxd.PupAsset `json:"assets"`
 	States     map[string]dogeboxd.PupState `json:"states"`
@@ -44,6 +46,7 @@ func (t api) getRawBS() BootstrapResponse {
 	}
 
 	return BootstrapResponse{
+		Version: version.GetDBXRelease(),
 		DevMode: t.config.DevMode,
 		Assets:  t.pups.GetAssetsMap(),
 		States:  t.pups.GetStateMap(),


### PR DESCRIPTION
This allows injecting release information into builds, allowing us to return the current "release" string to the client, as a precursor for system upgrades.

```sh
dogeboxd-env:/Users/adam/code/doge/dogeboxd $ DBX_NUR_HASH=my-fake-hash DBX_RELEASE=v0.3.0-beta make
...
dogeboxd-env:/Users/adam/code/doge/dogeboxd $ ./build/dbx version
Release: v0.3.0-beta
NurHash: my-fake-hash
Git: 0b89eb43c7ee41c6bd3a2ab44d556f482bd54e8f
Dirty: false
```

https://github.com/dogeorg/dogebox/blob/main/flake.nix#L34
https://github.com/dogeorg/dogebox-nur-packages/blob/main/pkgs/dogeboxd/default.nix#L46


