### PR TITLE
Expose disk usage to frontend, allow installing on used disks

### DIFF
--- a/pkg/sys.go
+++ b/pkg/sys.go
@@ -349,8 +349,9 @@ type SystemDiskSuitabilityEntry struct {
 }
 
 type SystemDiskSuitability struct {
-	Install SystemDiskSuitabilityEntry `json:"install"`
-	Storage SystemDiskSuitabilityEntry `json:"storage"`
+	Install       SystemDiskSuitabilityEntry `json:"install"`
+	Storage       SystemDiskSuitabilityEntry `json:"storage"`
+	IsAlreadyUsed bool                       `json:"isAlreadyUsed"`
 }
 
 type SystemDisk struct {

--- a/pkg/system/installation.go
+++ b/pkg/system/installation.go
@@ -74,7 +74,8 @@ func GetSystemDisks() ([]dogeboxd.SystemDisk, error) {
 		isSuitableInstallSize := device.Size.Int64 >= ten_gigabytes
 		isSuitableStorageSize := device.Size.Int64 >= three_hundred_gigabytes
 
-		isSuitableDevice := isOKDevice && !isMounted && !hasChildren && device.Size.Int64 > 0
+		isSuitableDevice := isOKDevice && device.Size.Int64 > 0
+		isAlreadyUsed := isMounted || hasChildren
 
 		// This block package only seems to return a single mount point.
 		// So we need to check if we're mounted at either / or /nix/store
@@ -103,6 +104,7 @@ func GetSystemDisks() ([]dogeboxd.SystemDisk, error) {
 				Usable: isUsableStorageDevice,
 				SizeOK: isSuitableStorageSize,
 			},
+			IsAlreadyUsed: isAlreadyUsed,
 		}
 
 		disks = append(disks, disk)


### PR DESCRIPTION
This changes the installer to allow installing onto disks that are "used", and exposes a flag that lets the frontend show a warning if that's the case.