### PR TITLE
Add shutdown and recovery routes to whitelist

### DIFF
--- a/pkg/web/session.go
+++ b/pkg/web/session.go
@@ -158,7 +158,9 @@ func authReq(dbx dogeboxd.Dogeboxd, sm dogeboxd.StateManager, route string, next
 		route == "GET /system/network/list" ||
 		route == "PUT /system/network/set-pending" ||
 		route == "GET /keys" ||
-		route == "POST /keys/create-master" {
+		route == "POST /keys/create-master" ||
+		route == "POST /system/host/shutdown" ||
+		route == "POST /system/host/reboot" {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			dbxis := sm.Get().Dogebox.InitialState
 


### PR DESCRIPTION
This is needed for the last installation step that provides a shutdown button
https://github.com/dogeorg/dpanel/issues/101