### PR TITLE
Enable WebSocket in recovery and publish installation progress logs

### DIFF
--- a/cmd/dogeboxd/server.go
+++ b/cmd/dogeboxd/server.go
@@ -103,10 +103,10 @@ func (t server) Start() {
 	c.Service("REST API", rest)
 	c.Service("UI Server", ui)
 	c.Service("System Updater", systemUpdater)
+	c.Service("WSock Relay", wsh)
 
 	if !t.config.Recovery {
 		c.Service("System Monitor", systemMonitor)
-		c.Service("WSock Relay", wsh)
 		c.Service("Pup Manager", pups)
 		c.Service("Internal Router", internalRouter)
 		c.Service("Admin Router", adminRouter)

--- a/pkg/system/installation.go
+++ b/pkg/system/installation.go
@@ -161,9 +161,14 @@ func GetBuildType() (string, error) {
 }
 
 func InstallToDisk(config dogeboxd.ServerConfig, dbxState dogeboxd.DogeboxState, name string, t dogeboxd.Dogeboxd) error {
+	t.Changes <- dogeboxd.Change{
+		ID:     "install-output",
+		Type:   "recovery",
+		Update: "Install to disk started",
+	}
 	if config.DevMode {
 		t.Changes <- dogeboxd.Change{
-			ID:     "test-install",
+			ID:     "warning",
 			Type:   "recovery",
 			Update: "Dev mode enabled, skipping installation. You probably do not want to do this. re-run without dev mode if you do.",
 		}

--- a/pkg/system/installation.go
+++ b/pkg/system/installation.go
@@ -160,9 +160,13 @@ func GetBuildType() (string, error) {
 	return strings.TrimSpace(string(buildType)), nil
 }
 
-func InstallToDisk(config dogeboxd.ServerConfig, dbxState dogeboxd.DogeboxState, name string) error {
+func InstallToDisk(config dogeboxd.ServerConfig, dbxState dogeboxd.DogeboxState, name string, t dogeboxd.Dogeboxd) error {
 	if config.DevMode {
-		log.Printf("Dev mode enabled, skipping installation. You probably do not want to do this. re-run without dev mode if you do.")
+		t.Changes <- dogeboxd.Change{
+			ID:     "test-install",
+			Type:   "recovery",
+			Update: "Dev mode enabled, skipping installation. You probably do not want to do this. re-run without dev mode if you do.",
+		}
 		return nil
 	}
 
@@ -205,7 +209,7 @@ func InstallToDisk(config dogeboxd.ServerConfig, dbxState dogeboxd.DogeboxState,
 
 	log.Printf("Starting to install to disk %s", name)
 
-	var installFn func(string) error
+	var installFn func(string, dogeboxd.Dogeboxd) error
 
 	installFn = dbxrootInstallToDisk
 
@@ -215,7 +219,7 @@ func InstallToDisk(config dogeboxd.ServerConfig, dbxState dogeboxd.DogeboxState,
 		installFn = dbxrootDDToDisk
 	}
 
-	if err := installFn(name); err != nil {
+	if err := installFn(name, t); err != nil {
 		log.Printf("Failed to install to disk: %v", err)
 		return err
 	}
@@ -225,16 +229,40 @@ func InstallToDisk(config dogeboxd.ServerConfig, dbxState dogeboxd.DogeboxState,
 	return nil
 }
 
-func dbxrootInstallToDisk(disk string) error {
+func dbxrootInstallToDisk(disk string, t dogeboxd.Dogeboxd) error {
+	var out bytes.Buffer
 	cmd := exec.Command("sudo", "_dbxroot", "install-to-disk", "--disk", disk, "--dbx-secret", DBXRootSecret)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	cmd.Stdout = io.MultiWriter(&out, os.Stdout)
+	cmd.Stderr = io.MultiWriter(&out, os.Stderr)
+
+	err := cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	t.Changes <- dogeboxd.Change{
+		ID:     "install-output",
+		Type:   "recovery",
+		Update: out.String(),
+	}
+	return nil
 }
 
-func dbxrootDDToDisk(toDisk string) error {
+func dbxrootDDToDisk(toDisk string, t dogeboxd.Dogeboxd) error {
+	var out bytes.Buffer
 	cmd := exec.Command("sudo", "_dbxroot", "dd-to-disk", "--target-disk", toDisk, "--dbx-secret", DBXRootSecret)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	cmd.Stdout = io.MultiWriter(&out, os.Stdout)
+	cmd.Stderr = io.MultiWriter(&out, os.Stderr)
+
+	err := cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	t.Changes <- dogeboxd.Change{
+		ID:     "dd-output",
+		Type:   "recovery",
+		Update: out.String(),
+	}
+	return nil
 }

--- a/pkg/web/install.go
+++ b/pkg/web/install.go
@@ -46,7 +46,7 @@ func (t api) installToDisk(w http.ResponseWriter, r *http.Request) {
 
 	dbxState := t.sm.Get().Dogebox
 
-	if err := system.InstallToDisk(t.config, dbxState, req.Disk); err != nil {
+	if err := system.InstallToDisk(t.config, dbxState, req.Disk, t.dbx); err != nil {
 		sendErrorResponse(w, http.StatusInternalServerError, "Error installing to disk: "+err.Error())
 		return
 	}

--- a/pkg/web/rest.go
+++ b/pkg/web/rest.go
@@ -84,6 +84,7 @@ func RESTAPI(
 		"GET /system/ssh/keys":        a.listSSHKeys,
 		"PUT /system/ssh/key":         a.addSSHKey,
 		"DELETE /system/ssh/key/{id}": a.removeSSHKey,
+		"/ws/recovery/":               a.getRecoverySocket,
 	}
 
 	// Normal routes are used when we are not in recovery mode.

--- a/pkg/web/rest.go
+++ b/pkg/web/rest.go
@@ -84,7 +84,7 @@ func RESTAPI(
 		"GET /system/ssh/keys":        a.listSSHKeys,
 		"PUT /system/ssh/key":         a.addSSHKey,
 		"DELETE /system/ssh/key/{id}": a.removeSSHKey,
-		"/ws/recovery/":               a.getRecoverySocket,
+		"/ws/state/":                  a.getUpdateSocket,
 	}
 
 	// Normal routes are used when we are not in recovery mode.

--- a/pkg/web/session.go
+++ b/pkg/web/session.go
@@ -161,7 +161,7 @@ func authReq(dbx dogeboxd.Dogeboxd, sm dogeboxd.StateManager, route string, next
 		route == "POST /keys/create-master" ||
 		route == "POST /system/host/shutdown" ||
 		route == "POST /system/host/reboot" ||
-		route == "/ws/recovery/" {
+		route == "/ws/state/" {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			dbxis := sm.Get().Dogebox.InitialState
 

--- a/pkg/web/session.go
+++ b/pkg/web/session.go
@@ -160,7 +160,8 @@ func authReq(dbx dogeboxd.Dogeboxd, sm dogeboxd.StateManager, route string, next
 		route == "GET /keys" ||
 		route == "POST /keys/create-master" ||
 		route == "POST /system/host/shutdown" ||
-		route == "POST /system/host/reboot" {
+		route == "POST /system/host/reboot" ||
+		route == "/ws/recovery/" {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			dbxis := sm.Get().Dogebox.InitialState
 

--- a/pkg/web/websocket.go
+++ b/pkg/web/websocket.go
@@ -32,14 +32,6 @@ func (t api) getUpdateSocket(w http.ResponseWriter, r *http.Request) {
 	t.ws.GetWSHandler(initialPayload).ServeHTTP(w, r)
 }
 
-// Handle incomming websocket connections for recovery updates
-func (t api) getRecoverySocket(w http.ResponseWriter, r *http.Request) {
-	initialPayload := func() any {
-		return dogeboxd.Change{ID: "internal", Error: "", Type: "bootstrap", Update: t.getRawBS()}
-	}
-	t.ws.GetWSHandler(initialPayload).ServeHTTP(w, r)
-}
-
 // Handle incomming websocket connections for log output
 func (t api) getLogSocket(w http.ResponseWriter, r *http.Request) {
 	PupID := r.PathValue("PupID")

--- a/pkg/web/websocket.go
+++ b/pkg/web/websocket.go
@@ -32,6 +32,14 @@ func (t api) getUpdateSocket(w http.ResponseWriter, r *http.Request) {
 	t.ws.GetWSHandler(initialPayload).ServeHTTP(w, r)
 }
 
+// Handle incomming websocket connections for recovery updates
+func (t api) getRecoverySocket(w http.ResponseWriter, r *http.Request) {
+	initialPayload := func() any {
+		return dogeboxd.Change{ID: "internal", Error: "", Type: "bootstrap", Update: t.getRawBS()}
+	}
+	t.ws.GetWSHandler(initialPayload).ServeHTTP(w, r)
+}
+
 // Handle incomming websocket connections for log output
 func (t api) getLogSocket(w http.ResponseWriter, r *http.Request) {
 	PupID := r.PathValue("PupID")

--- a/pkg/web/websocket_updates.go
+++ b/pkg/web/websocket_updates.go
@@ -3,7 +3,6 @@ package web
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	dogeboxd "github.com/dogeorg/dogeboxd/pkg"
@@ -18,11 +17,6 @@ type WSRelay struct {
 }
 
 func NewWSRelay(config dogeboxd.ServerConfig, relay chan dogeboxd.Change) WSRelay {
-	if config.Recovery {
-		log.Printf("In recovery mode: not initialising WSRelay")
-		return WSRelay{}
-	}
-
 	return WSRelay{
 		config: config,
 		socks:  []*WSCONN{},        // all current connections


### PR DESCRIPTION
Added the existing WebSocket to recovery.

This allows dogeboxd to publish installation progress messages to a log viewer in dogeboxd
![image](https://github.com/user-attachments/assets/4363e348-e86e-45ee-a5be-c62a8548bd95)

Change summary:
- WebSocket service always included (previously only added when not in recovery)
- Publish install messages to new recovery type, as well as stdout/stderr from install-to-disk and dd-to-disk
- Allow the /ws/state/ route in recovery
- Don't require authentication when connecting to /ws/state/