### PR TITLE
Sort out keymap listing

### DIFF
--- a/pkg/system/keymaps.go
+++ b/pkg/system/keymaps.go
@@ -1,11 +1,8 @@
 package system
 
 import (
-	"bufio"
-	"os/exec"
-	"regexp"
-	"sort"
-	"strings"
+    _ "embed"
+    "encoding/json"
 )
 
 type Keymap struct {
@@ -13,60 +10,20 @@ type Keymap struct {
 	Value string `json:"value"`
 }
 
+var (
+    // File keymaps.json contains manually generated keymaps list.
+    // TODO: Find a way to automatically generate this list
+    //go:embed keymaps.json
+    data []byte
+    precompiled = func() (s []Keymap) {
+        if err := json.Unmarshal(data, &s); err != nil {
+            panic(err)
+        }
+        return
+    }()
+)
+
+
 func GetKeymaps() ([]Keymap, error) {
-	// Execute the xkbcli command
-	cmd := exec.Command("xkbcli", "list", "--load-exotic")
-	output, err := cmd.Output()
-	if err != nil {
-		return nil, err
-	}
-
-	// Convert output to a string and create a scanner
-	scanner := bufio.NewScanner(strings.NewReader(string(output)))
-
-	// Regular expressions to match layout and description
-	layoutRegex := regexp.MustCompile(`layout: *'([^']+)'`)
-	descriptionRegex := regexp.MustCompile(`description: *(.*)`)
-
-	var layouts []Keymap
-	layoutMap := make(map[string]bool)
-	var currentLayout string
-
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		// Match the layout line
-		if layoutMatch := layoutRegex.FindStringSubmatch(line); layoutMatch != nil {
-			layout := layoutMatch[1]
-			if layoutMap[layout] {
-				continue
-			}
-			currentLayout = layout
-			layoutMap[layout] = true
-		}
-
-		// Match the description line and add to the slice
-		if currentLayout != "" {
-			if descMatch := descriptionRegex.FindStringSubmatch(line); descMatch != nil {
-				description := descMatch[1]
-				layouts = append(layouts, Keymap{Name: currentLayout, Value: description})
-				currentLayout = ""
-			}
-		}
-	}
-
-	// Sort layouts by name for consistent output
-	sort.Slice(layouts, func(i, j int) bool {
-		return layouts[i].Name < layouts[j].Name
-	})
-
-	// Remove layouts with name "custom"
-	filteredLayouts := make([]Keymap, 0, len(layouts))
-	for _, layout := range layouts {
-		if layout.Name != "custom" {
-			filteredLayouts = append(filteredLayouts, layout)
-		}
-	}
-
-	return filteredLayouts, nil
+	return precompiled, nil
 }

--- a/pkg/system/keymaps.json
+++ b/pkg/system/keymaps.json
@@ -1,0 +1,342 @@
+[
+  {
+    "name": "ANSI-dvorak",
+    "value": "ANSI Dvorak Layout"
+  },
+  {
+    "name": "adnw",
+    "value": "Alternate German Keyboard Layout (AdNW)"
+  },
+  {
+    "name": "amiga-de",
+    "value": "Amiga German Keyboard"
+  },
+  {
+    "name": "amiga-us",
+    "value": "Amiga US Keyboard"
+  },
+  {
+    "name": "apple-a1048-sv",
+    "value": "Apple Swedish A1048 Keyboard"
+  },
+  {
+    "name": "apple-a1243-sv",
+    "value": "Apple Swedish A1243 Keyboard"
+  },
+  {
+    "name": "atari-de",
+    "value": "Atari German Keyboard"
+  },
+  {
+    "name": "atari-se",
+    "value": "Atari Swedish Keyboard"
+  },
+  {
+    "name": "atari-uk-falcon",
+    "value": "Atari UK Falcon Keyboard"
+  },
+  {
+    "name": "atari-us",
+    "value": "Atari US Keyboard"
+  },
+  {
+    "name": "bashkir",
+    "value": "Bashkir Keyboard Layout"
+  },
+  {
+    "name": "be-latin1",
+    "value": "Belgian Latin-1 Keyboard"
+  },
+  {
+    "name": "bg-cp1251",
+    "value": "Bulgarian CP1251 Keyboard"
+  },
+  {
+    "name": "bg-cp855",
+    "value": "Bulgarian CP855 Keyboard"
+  },
+  {
+    "name": "bg_bds-cp1251",
+    "value": "Bulgarian BDS CP1251 Keyboard"
+  },
+  {
+    "name": "bg_bds-utf8",
+    "value": "Bulgarian BDS UTF-8 Keyboard"
+  },
+  {
+    "name": "bg_pho-cp1251",
+    "value": "Bulgarian Phonetic CP1251 Keyboard"
+  },
+  {
+    "name": "bg_pho-utf8",
+    "value": "Bulgarian Phonetic UTF-8 Keyboard"
+  },
+  {
+    "name": "br-abnt",
+    "value": "Brazilian ABNT Keyboard"
+  },
+  {
+    "name": "br-abnt2",
+    "value": "Brazilian ABNT2 Keyboard"
+  },
+  {
+    "name": "br-latin1-abnt2",
+    "value": "Brazilian Latin-1 ABNT2 Keyboard"
+  },
+  {
+    "name": "br-latin1-us",
+    "value": "Brazilian Latin-1 US Keyboard"
+  },
+  {
+    "name": "by",
+    "value": "Belarusian Keyboard Layout"
+  },
+  {
+    "name": "by-cp1251",
+    "value": "Belarusian CP1251 Keyboard"
+  },
+  {
+    "name": "ca",
+    "value": "Canadian Keyboard Layout"
+  },
+  {
+    "name": "colemak",
+    "value": "Colemak Keyboard Layout"
+  },
+  {
+    "name": "croat",
+    "value": "Croatian Keyboard Layout"
+  },
+  {
+    "name": "cz",
+    "value": "Czech Keyboard Layout"
+  },
+  {
+    "name": "cz-cp1250",
+    "value": "Czech CP1250 Keyboard"
+  },
+  {
+    "name": "cz-lat2",
+    "value": "Czech Latin-2 Keyboard"
+  },
+  {
+    "name": "cz-lat2-prog",
+    "value": "Czech Latin-2 Programmers Keyboard"
+  },
+  {
+    "name": "cz-qwertz",
+    "value": "Czech QWERTZ Keyboard"
+  },
+  {
+    "name": "cz-us-qwertz",
+    "value": "Czech US QWERTZ Keyboard"
+  },
+  {
+    "name": "de",
+    "value": "German Keyboard Layout"
+  },
+  {
+    "name": "de-latin1",
+    "value": "German Latin-1 Keyboard"
+  },
+  {
+    "name": "de-latin1-nodeadkeys",
+    "value": "German Latin-1 Keyboard (No Dead Keys)"
+  },
+  {
+    "name": "de-mobii",
+    "value": "German Mobii Keyboard"
+  },
+  {
+    "name": "dk",
+    "value": "Danish Keyboard Layout"
+  },
+  {
+    "name": "dk-latin1",
+    "value": "Danish Latin-1 Keyboard"
+  },
+  {
+    "name": "dvorak",
+    "value": "Dvorak Keyboard Layout"
+  },
+  {
+    "name": "dvorak-ca-fr",
+    "value": "Canadian French Dvorak Layout"
+  },
+  {
+    "name": "dvorak-de",
+    "value": "German Dvorak Layout"
+  },
+  {
+    "name": "dvorak-es",
+    "value": "Spanish Dvorak Layout"
+  },
+  {
+    "name": "dvorak-fr",
+    "value": "French Dvorak Layout"
+  },
+  {
+    "name": "dvorak-no",
+    "value": "Norwegian Dvorak Layout"
+  },
+  {
+    "name": "dvorak-sv-a1",
+    "value": "Swedish Dvorak A1 Layout"
+  },
+  {
+    "name": "dvorak-sv-a5",
+    "value": "Swedish Dvorak A5 Layout"
+  },
+  {
+    "name": "es",
+    "value": "Spanish Keyboard Layout"
+  },
+  {
+    "name": "es-cp850",
+    "value": "Spanish CP850 Keyboard"
+  },
+  {
+    "name": "es-olpc",
+    "value": "Spanish OLPC Keyboard"
+  },
+  {
+    "name": "et",
+    "value": "Estonian Keyboard Layout"
+  },
+  {
+    "name": "fi",
+    "value": "Finnish Keyboard Layout"
+  },
+  {
+    "name": "fr",
+    "value": "French Keyboard Layout"
+  },
+  {
+    "name": "fr-bepo",
+    "value": "French B\u00c9PO Keyboard"
+  },
+  {
+    "name": "fr-latin1",
+    "value": "French Latin-1 Keyboard"
+  },
+  {
+    "name": "fr-latin9",
+    "value": "French Latin-9 Keyboard"
+  },
+  {
+    "name": "gr",
+    "value": "Greek Keyboard Layout"
+  },
+  {
+    "name": "hu",
+    "value": "Hungarian Keyboard Layout"
+  },
+  {
+    "name": "ie",
+    "value": "Irish Keyboard Layout"
+  },
+  {
+    "name": "il",
+    "value": "Hebrew Keyboard Layout"
+  },
+  {
+    "name": "is-latin1",
+    "value": "Icelandic Latin-1 Keyboard"
+  },
+  {
+    "name": "it",
+    "value": "Italian Keyboard Layout"
+  },
+  {
+    "name": "it-ibm",
+    "value": "Italian IBM Keyboard"
+  },
+  {
+    "name": "jp106",
+    "value": "Japanese 106-Key Keyboard"
+  },
+  {
+    "name": "kazakh",
+    "value": "Kazakh Keyboard Layout"
+  },
+  {
+    "name": "lt",
+    "value": "Lithuanian Keyboard Layout"
+  },
+  {
+    "name": "lv",
+    "value": "Latvian Keyboard Layout"
+  },
+  {
+    "name": "mk",
+    "value": "Macedonian Keyboard Layout"
+  },
+  {
+    "name": "nl",
+    "value": "Dutch Keyboard Layout"
+  },
+  {
+    "name": "no",
+    "value": "Norwegian Keyboard Layout"
+  },
+  {
+    "name": "pl",
+    "value": "Polish Keyboard Layout"
+  },
+  {
+    "name": "pt-latin1",
+    "value": "Portuguese Latin-1 Keyboard"
+  },
+  {
+    "name": "pt-latin9",
+    "value": "Portuguese Latin-9 Keyboard"
+  },
+  {
+    "name": "ro",
+    "value": "Romanian Keyboard Layout"
+  },
+  {
+    "name": "ru",
+    "value": "Russian Keyboard Layout"
+  },
+  {
+    "name": "se-fi-ir209",
+    "value": "Swedish-Finnish IR209 Keyboard"
+  },
+  {
+    "name": "se-ir209",
+    "value": "Swedish IR209 Keyboard"
+  },
+  {
+    "name": "se-lat6",
+    "value": "Swedish Latin-6 Keyboard"
+  },
+  {
+    "name": "sk-qwertz",
+    "value": "Slovak QWERTZ Keyboard"
+  },
+  {
+    "name": "sr-cy",
+    "value": "Serbian Cyrillic Keyboard"
+  },
+  {
+    "name": "sr-latin",
+    "value": "Serbian Latin Keyboard"
+  },
+  {
+    "name": "tr_q-latin5",
+    "value": "Turkish Q Latin-5 Keyboard"
+  },
+  {
+    "name": "ua",
+    "value": "Ukrainian Keyboard Layout"
+  },
+  {
+    "name": "uk",
+    "value": "UK Keyboard Layout"
+  },
+  {
+    "name": "us",
+    "value": "US Keyboard Layout"
+  }
+]


### PR DESCRIPTION
Trying to make listing the console keymaps better. Currently there's a mismatch between the listed keymaps from xkbcli and the list nixos loadkeys uses.

I'm certain that the command to invoke the `localectl list-keymaps` command could be better. But it's currently like this, since the command needs a temporary env var `SYSTEMD_KEYMAP_DIRECTORIES` set to the value of the evaluation of a nix statement with the appended directory to allow the command to list the proper keymaps.

`localectl` is really simple and only really lists the names of keymaps and doesn't provide any other information, so we'll lose out on getting any descriptions out.