### PR TITLE
Run system updates through job manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ build
 go.work
 vendor
 result
+.gocache
 
 #Claude files
 .claude

--- a/pkg/dogeboxd.go
+++ b/pkg/dogeboxd.go
@@ -340,6 +340,9 @@ func (t Dogeboxd) jobDispatcher(j Job) {
 	case RemoveBinaryCache:
 		t.enqueue(j)
 
+	case SystemUpdate:
+		t.enqueue(j)
+
 	// Pup router actions
 	case UpdateMetrics:
 		t.Pups.UpdateMetrics(a)

--- a/pkg/events.go
+++ b/pkg/events.go
@@ -129,6 +129,11 @@ type RemoveSSHKey struct {
 // Import blockchain data to the system (not tied to a specific pup)
 type ImportBlockchainData struct{}
 
+type SystemUpdate struct {
+	Package string
+	Version string
+}
+
 type AddBinaryCache struct {
 	Host string
 	Key  string

--- a/pkg/jobs.go
+++ b/pkg/jobs.go
@@ -317,6 +317,8 @@ func (jm *JobManager) getDisplayName(j Job) string {
 		return "Add Binary Cache"
 	case RemoveBinaryCache:
 		return "Remove Binary Cache"
+	case SystemUpdate:
+		return "System Update"
 	case UpdateMetrics:
 		return "Update Metrics"
 	default:

--- a/pkg/system/updater.go
+++ b/pkg/system/updater.go
@@ -147,6 +147,17 @@ func (t SystemUpdater) Run(started, stopped chan bool, stop chan context.Context
 						}
 						t.done <- j
 
+					case dogeboxd.SystemUpdate:
+						logger := j.Logger.Step("system update")
+						logger.Progress(5).Logf("Starting system update to %s", a.Version)
+						if err := DoSystemUpdate(a.Package, a.Version); err != nil {
+							logger.Errf("System update failed: %v", err)
+							j.Err = err.Error()
+						} else {
+							logger.Progress(100).Logf("System update to %s completed", a.Version)
+						}
+						t.done <- j
+
 					default:
 						fmt.Printf("Unknown action type: %v\n", a)
 					}

--- a/pkg/web/upgrade.go
+++ b/pkg/web/upgrade.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 
+	dogeboxd "github.com/dogeorg/dogeboxd/pkg"
 	"github.com/dogeorg/dogeboxd/pkg/system"
 	"github.com/dogeorg/dogeboxd/pkg/version"
 )
@@ -103,12 +104,10 @@ func (t api) commenceUpdate(w http.ResponseWriter, r *http.Request) {
 		packageName = "os"
 	}
 
-	// Execute the system update
-	err = system.DoSystemUpdate(packageName, req.Version)
-	if err != nil {
-		sendErrorResponse(w, http.StatusInternalServerError, "Error executing update: "+err.Error())
-		return
-	}
+	id := t.dbx.AddAction(dogeboxd.SystemUpdate{Package: packageName, Version: req.Version})
 
-	sendResponse(w, map[string]bool{"success": true})
+	sendResponse(w, map[string]any{
+		"success": true,
+		"id":      id,
+	})
 }


### PR DESCRIPTION
**System updates are now processed through the job manager.**
This ensures the following:
- Success and failure is shown to the user
- Update progress has some refresh resilience 
- Logs are visible through the system activity page
- commenceUpdate function returns success as soon as the update action is added

Also note this PR disables the update button while an update is in progress or queued: https://github.com/Dogebox-WG/dpanel/pull/160