### PR TITLE
add description to manifest

### DIFF
--- a/pkg/manifest.go
+++ b/pkg/manifest.go
@@ -211,4 +211,5 @@ type PupManifestMetric struct {
 	Label       string `json:"label"`
 	Type        string `json:"type"` // string, int, float
 	HistorySize int    `json:"history"`
+	Description string `json:"description,omitempty"`
 }


### PR DESCRIPTION
Add optional description field so pups can include metric descriptions in the manifest per https://dogebox.org/docs/pup/metrics.