### PR TITLE
Feat(installer): Disable `create_ap` 

### DIFF
--- a/pkg/system/nix/templates/network.nix
+++ b/pkg/system/nix/templates/network.nix
@@ -1,6 +1,8 @@
 { config, pkgs, ... }:
 
 {
+  services.create_ap.enable = false; # Disable create_ap in case it was enabled by the T6 Installer.
+
   networking = {
     {{if .USE_ETHERNET}}
     interfaces = {


### PR DESCRIPTION
in case it was enabled  by the T6 installer