### PR TITLE
Correcting nix hash log order

### DIFF
--- a/pkg/system/updater.go
+++ b/pkg/system/updater.go
@@ -234,7 +234,7 @@ func (t SystemUpdater) verifyNixFileHash(pupPath string, manifest dogeboxd.PupMa
 	actualHash := fmt.Sprintf("%x", nixFileSha256)
 
 	if actualHash != manifest.Container.Build.NixFileSha256 {
-		logger.Errf("Nix file hash mismatch: expected %s, got %s", actualHash, manifest.Container.Build.NixFileSha256)
+		logger.Errf("Nix file hash mismatch! Manifest Hash: %s, Computed Hash: %s", manifest.Container.Build.NixFileSha256, actualHash)
 		if !isDevMode {
 			return fmt.Errorf("nix file hash mismatch")
 		}


### PR DESCRIPTION
Noticed that when a pup manifest's nixFileSha256 isn't updated, the log "Nix file hash mismatch: expected <correct hash>, got <incorrect hash>" was back to front