### PR TITLE
Support pre-release system updates

### DIFF
--- a/pkg/system/upgrades.go
+++ b/pkg/system/upgrades.go
@@ -146,7 +146,7 @@ func GetUpgradableReleasesWithFetcher(includePreReleases bool, fetcher RepoTagsF
 }
 
 func DoSystemUpdate(pkg string, updateVersion string, logger dogeboxd.SubLogger) error {
-	upgradableReleases, err := GetUpgradableReleases(false)
+	upgradableReleases, err := GetUpgradableReleases(true)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Backend support for https://github.com/Dogebox-WG/dpanel/pull/207

Most of the support is existing, but the list of updates obtained by `DoSystemUpdate` never included pre-release versions. Until now...