### PR TITLE
Log viewer improvements - backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,15 +33,24 @@ multipassdev:
 
 dpanel-build:
 	@set -eu; \
+	ROLLUP_OS=$$(uname -s | tr '[:upper:]' '[:lower:]'); \
+	ROLLUP_ARCH=$$(uname -m | sed 's/x86_64/x64/'); \
+	NEED_INSTALL=0; \
+	if [ ! -x "$(DPANEL_DIR)/node_modules/.bin/vite" ]; then \
+		NEED_INSTALL=1; \
+	elif ! ls "$(DPANEL_DIR)/node_modules/@rollup/rollup-$${ROLLUP_OS}-$${ROLLUP_ARCH}"* >/dev/null 2>&1; then \
+		echo "dpanel: node_modules built for wrong platform, reinstalling..."; \
+		NEED_INSTALL=1; \
+	fi; \
 	if command -v npm >/dev/null 2>&1; then \
-		if [ ! -x "$(DPANEL_DIR)/node_modules/.bin/vite" ]; then \
+		if [ "$$NEED_INSTALL" = "1" ]; then \
 			npm --prefix "$(DPANEL_DIR)" ci; \
 		fi; \
 		npm --prefix "$(DPANEL_DIR)" run build; \
 	elif command -v nix >/dev/null 2>&1; then \
-		DPANEL_DIR="$(DPANEL_DIR)" nix shell nixpkgs#nodejs_22 --command sh -lc '\
+		DPANEL_DIR="$(DPANEL_DIR)" NEED_INSTALL="$$NEED_INSTALL" nix shell nixpkgs#nodejs_22 --command sh -lc '\
 			cd "$$DPANEL_DIR" && \
-			if [ ! -x node_modules/.bin/vite ]; then npm ci; fi && \
+			if [ "$$NEED_INSTALL" = "1" ]; then npm ci; fi && \
 			npm run build \
 		'; \
 	else \

--- a/pkg/dogeboxd.go
+++ b/pkg/dogeboxd.go
@@ -847,6 +847,10 @@ func (t Dogeboxd) GetLogChannel(PupID string, resumeToken *string) (context.Canc
 }
 
 func (t Dogeboxd) GetLogTail(PupID string, limit int) ([]string, *string, error) {
+	if limit <= 0 {
+		return nil, nil, fmt.Errorf("Log tail limit must be greater than zero")
+	}
+
 	service, ok := allowedJournalServices[PupID]
 	if ok {
 		lines, resumeToken, err := t.JournalReader.GetJournalTail(service, limit)
@@ -887,6 +891,10 @@ func (t Dogeboxd) GetJobLogChannel(JobID string, resumeToken *string) (context.C
 }
 
 func (t Dogeboxd) GetJobLogTail(JobID string, limit int) ([]string, *string, error) {
+	if limit <= 0 {
+		return nil, nil, fmt.Errorf("Log tail limit must be greater than zero")
+	}
+
 	_, err := t.JobManager.GetJob(JobID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("job not found: %s", JobID)

--- a/pkg/dogeboxd.go
+++ b/pkg/dogeboxd.go
@@ -44,6 +44,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"sync"
 	"time"
 
@@ -817,11 +818,14 @@ var allowedJournalServices = map[string]string{
 	"dkm": "dkm.service",
 }
 
-func (t Dogeboxd) GetLogChannel(PupID string) (context.CancelFunc, chan string, error) {
+func (t Dogeboxd) GetLogChannel(PupID string, resumeToken *string) (context.CancelFunc, chan string, error) {
 	// We read dogeboxd and dkm from the host systemd journal,
 	// and read everything else (pups) from the container logs we export.
 	service, ok := allowedJournalServices[PupID]
 	if ok {
+		if resumeToken != nil {
+			return t.JournalReader.GetJournalChannelFromCursor(service, *resumeToken)
+		}
 		return t.JournalReader.GetJournalChannel(service)
 	}
 
@@ -831,18 +835,84 @@ func (t Dogeboxd) GetLogChannel(PupID string) (context.CancelFunc, chan string, 
 		return nil, nil, err
 	}
 
+	if resumeToken != nil {
+		offset, err := parseLogOffsetResumeToken(*resumeToken)
+		if err != nil {
+			return nil, nil, err
+		}
+		return t.logtailer.GetChannelFromOffset(PupID, offset)
+	}
+
 	return t.logtailer.GetChannel(PupID)
+}
+
+func (t Dogeboxd) GetLogTail(PupID string, limit int) ([]string, *string, error) {
+	service, ok := allowedJournalServices[PupID]
+	if ok {
+		lines, resumeToken, err := t.JournalReader.GetJournalTail(service, limit)
+		return lines, resumeToken, err
+	}
+
+	_, _, err := t.Pups.GetPup(PupID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	lines, resumeToken, err := t.logtailer.GetTail(PupID, limit)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return lines, logOffsetResumeToken(resumeToken), nil
 }
 
 // GetJobLogChannel returns a log channel for a specific job
 // Streams logs from the job's ActionLogger in real-time (same system as pup logs)
-func (t Dogeboxd) GetJobLogChannel(JobID string) (context.CancelFunc, chan string, error) {
+func (t Dogeboxd) GetJobLogChannel(JobID string, resumeToken *string) (context.CancelFunc, chan string, error) {
 	// Verify job exists
 	_, err := t.JobManager.GetJob(JobID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("job not found: %s", JobID)
 	}
 
-	// Get log channel from the action logger for this job
+	if resumeToken != nil {
+		offset, err := parseLogOffsetResumeToken(*resumeToken)
+		if err != nil {
+			return nil, nil, err
+		}
+		return t.logtailer.GetChannelFromOffset(JobID, offset)
+	}
+
 	return t.logtailer.GetChannel(JobID)
+}
+
+func (t Dogeboxd) GetJobLogTail(JobID string, limit int) ([]string, *string, error) {
+	_, err := t.JobManager.GetJob(JobID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("job not found: %s", JobID)
+	}
+
+	lines, resumeToken, err := t.logtailer.GetTail(JobID, limit)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return lines, logOffsetResumeToken(resumeToken), nil
+}
+
+func parseLogOffsetResumeToken(resumeToken string) (int64, error) {
+	offset, err := strconv.ParseInt(resumeToken, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid log resume token")
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	return offset, nil
+}
+
+func logOffsetResumeToken(offset int64) *string {
+	resumeToken := strconv.FormatInt(offset, 10)
+	return &resumeToken
 }

--- a/pkg/sys.go
+++ b/pkg/sys.go
@@ -41,10 +41,14 @@ type SystemMonitor interface {
 // when done
 type JournalReader interface {
 	GetJournalChannel(string) (context.CancelFunc, chan string, error)
+	GetJournalChannelFromCursor(string, string) (context.CancelFunc, chan string, error)
+	GetJournalTail(string, int) ([]string, *string, error)
 }
 
 type LogTailer interface {
 	GetChannel(string) (context.CancelFunc, chan string, error)
+	GetChannelFromOffset(string, int64) (context.CancelFunc, chan string, error)
+	GetTail(string, int) ([]string, int64, error)
 }
 
 // SystemMonitor issues these for monitored PUPs

--- a/pkg/system/journal.go
+++ b/pkg/system/journal.go
@@ -105,7 +105,7 @@ func (t JournalReader) getJournalChannel(service string, cursor *string) (contex
 
 func (t JournalReader) GetJournalTail(service string, limit int) ([]string, *string, error) {
 	if limit <= 0 {
-		return []string{}, nil, nil
+		return nil, nil, fmt.Errorf("Log tail limit must be greater than zero")
 	}
 
 	j, err := sdjournal.NewJournal()

--- a/pkg/system/journal.go
+++ b/pkg/system/journal.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/coreos/go-systemd/sdjournal"
 	dogeboxd "github.com/Dogebox-WG/dogeboxd/pkg"
+	"github.com/coreos/go-systemd/sdjournal"
 )
 
 func NewJournalReader(config dogeboxd.ServerConfig) JournalReader {
@@ -20,6 +20,14 @@ type JournalReader struct {
 }
 
 func (t JournalReader) GetJournalChannel(service string) (context.CancelFunc, chan string, error) {
+	return t.getJournalChannel(service, nil)
+}
+
+func (t JournalReader) GetJournalChannelFromCursor(service string, cursor string) (context.CancelFunc, chan string, error) {
+	return t.getJournalChannel(service, &cursor)
+}
+
+func (t JournalReader) getJournalChannel(service string, cursor *string) (context.CancelFunc, chan string, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	out := make(chan string, 10)
@@ -28,6 +36,7 @@ func (t JournalReader) GetJournalChannel(service string) (context.CancelFunc, ch
 		j, err := sdjournal.NewJournal()
 		if err != nil {
 			fmt.Println(err)
+			close(out)
 			return
 		}
 		defer j.Close()
@@ -36,27 +45,40 @@ func (t JournalReader) GetJournalChannel(service string) (context.CancelFunc, ch
 		err = j.AddMatch(fmt.Sprintf("_SYSTEMD_UNIT=%s", service))
 		if err != nil {
 			fmt.Println(err)
+			close(out)
 			return
 		}
 
-		// Seek to the end of the journal
-		err = j.SeekTail()
-		if err != nil {
-			fmt.Println(err)
-			return
-		}
+		if cursor != nil {
+			err = j.SeekCursor(*cursor)
+			if err != nil {
+				fmt.Println(err)
+				close(out)
+				return
+			}
 
-		// skip back 50 lines..
-		_, err = j.PreviousSkip(50)
-		if err != nil {
-			fmt.Println(err)
-			return
+			// Advance once so subsequent reads only emit entries after the cursor.
+			_, err = j.Next()
+			if err != nil {
+				fmt.Println(err)
+				close(out)
+				return
+			}
+		} else {
+			// Seek to the end of the journal
+			err = j.SeekTail()
+			if err != nil {
+				fmt.Println(err)
+				close(out)
+				return
+			}
 		}
 
 		for {
 			select {
 			case <-ctx.Done():
-				break
+				close(out)
+				return
 			default:
 				i, err := j.Next()
 				if err != nil {
@@ -79,4 +101,58 @@ func (t JournalReader) GetJournalChannel(service string) (context.CancelFunc, ch
 		}
 	}()
 	return cancel, out, nil
+}
+
+func (t JournalReader) GetJournalTail(service string, limit int) ([]string, *string, error) {
+	if limit <= 0 {
+		return []string{}, nil, nil
+	}
+
+	j, err := sdjournal.NewJournal()
+	if err != nil {
+		return nil, nil, err
+	}
+	defer j.Close()
+
+	err = j.AddMatch(fmt.Sprintf("_SYSTEMD_UNIT=%s", service))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = j.SeekTail()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	_, err = j.PreviousSkip(uint64(limit))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	lines := []string{}
+	var lastCursor *string
+	for {
+		n, err := j.Next()
+		if err != nil {
+			return nil, nil, err
+		}
+		if n == 0 {
+			break
+		}
+
+		entry, err := j.GetEntry()
+		if err != nil {
+			return nil, nil, err
+		}
+
+		cursor, err := j.GetCursor()
+		if err != nil {
+			return nil, nil, err
+		}
+
+		lastCursor = &cursor
+		lines = append(lines, entry.Fields["MESSAGE"])
+	}
+
+	return lines, lastCursor, nil
 }

--- a/pkg/system/logtailer.go
+++ b/pkg/system/logtailer.go
@@ -40,6 +40,7 @@ func (t LogTailer) GetChannelFromOffset(pupId string, startOffset int64) (contex
 	go func() {
 		logFile := filepath.Join(t.config.ContainerLogDir, "pup-"+pupId)
 
+		// Wait for the file to be created (up to 30 seconds)
 		file, err := waitForLogFile(logFile)
 		if err != nil {
 			// File never appeared, close the channel

--- a/pkg/system/logtailer.go
+++ b/pkg/system/logtailer.go
@@ -15,6 +15,8 @@ import (
 
 const maxInitialLines = 1000
 const tailReadChunkSize int64 = 8192
+const logFileOpenAttempts = 300
+const logFileOpenRetryDelay = 100 * time.Millisecond
 
 func NewLogTailer(config dogeboxd.ServerConfig) LogTailer {
 	return LogTailer{
@@ -109,12 +111,15 @@ func (t LogTailer) GetTail(pupId string, limit int) ([]string, int64, error) {
 func waitForLogFile(logFile string) (*os.File, error) {
 	var file *os.File
 	var err error
-	for i := 0; i < 300; i++ { // 300 * 100ms = 30 seconds
+	for i := 0; i < logFileOpenAttempts; i++ {
+		if i > 0 {
+			time.Sleep(logFileOpenRetryDelay)
+		}
+
 		file, err = os.Open(logFile)
 		if err == nil {
 			return file, nil
 		}
-		time.Sleep(100 * time.Millisecond)
 	}
 
 	return nil, err

--- a/pkg/system/logtailer.go
+++ b/pkg/system/logtailer.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"io"
 	"log"
@@ -11,6 +12,9 @@ import (
 
 	dogeboxd "github.com/Dogebox-WG/dogeboxd/pkg"
 )
+
+const maxInitialLines = 1000
+const tailReadChunkSize int64 = 8192
 
 func NewLogTailer(config dogeboxd.ServerConfig) LogTailer {
 	return LogTailer{
@@ -23,6 +27,10 @@ type LogTailer struct {
 }
 
 func (t LogTailer) GetChannel(pupId string) (context.CancelFunc, chan string, error) {
+	return t.GetChannelFromOffset(pupId, -1)
+}
+
+func (t LogTailer) GetChannelFromOffset(pupId string, startOffset int64) (context.CancelFunc, chan string, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	out := make(chan string, 10)
@@ -30,17 +38,7 @@ func (t LogTailer) GetChannel(pupId string) (context.CancelFunc, chan string, er
 	go func() {
 		logFile := filepath.Join(t.config.ContainerLogDir, "pup-"+pupId)
 
-		// Wait for the file to be created (up to 30 seconds)
-		var file *os.File
-		var err error
-		for i := 0; i < 300; i++ { // 300 * 100ms = 30 seconds
-			file, err = os.Open(logFile)
-			if err == nil {
-				break
-			}
-			time.Sleep(100 * time.Millisecond)
-		}
-
+		file, err := waitForLogFile(logFile)
 		if err != nil {
 			// File never appeared, close the channel
 			log.Printf("Log file never appeared: %s", logFile)
@@ -51,26 +49,13 @@ func (t LogTailer) GetChannel(pupId string) (context.CancelFunc, chan string, er
 
 		log.Printf("Opened log file: %s", file.Name())
 
-		// First, send existing content
-		_, err = file.Seek(0, io.SeekStart)
+		offset, err := resolveStartOffset(file, startOffset)
 		if err != nil {
 			close(out)
 			return
 		}
 
-		// Read and send all existing content
-		scanner := bufio.NewScanner(file)
-		for scanner.Scan() {
-			select {
-			case <-ctx.Done():
-				close(out)
-				return
-			case out <- scanner.Text():
-			}
-		}
-
-		// Now seek to the end for live streaming
-		_, err = file.Seek(0, io.SeekEnd)
+		_, err = file.Seek(offset, io.SeekStart)
 		if err != nil {
 			close(out)
 			return
@@ -99,4 +84,141 @@ func (t LogTailer) GetChannel(pupId string) (context.CancelFunc, chan string, er
 
 	}()
 	return cancel, out, nil
+}
+
+func (t LogTailer) GetTail(pupId string, limit int) ([]string, int64, error) {
+	logFile := filepath.Join(t.config.ContainerLogDir, "pup-"+pupId)
+
+	file, err := os.Open(logFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []string{}, 0, nil
+		}
+		return nil, 0, err
+	}
+	defer file.Close()
+
+	lines, cursor, err := readLastLines(file, limit)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return lines, cursor, nil
+}
+
+func waitForLogFile(logFile string) (*os.File, error) {
+	var file *os.File
+	var err error
+	for i := 0; i < 300; i++ { // 300 * 100ms = 30 seconds
+		file, err = os.Open(logFile)
+		if err == nil {
+			return file, nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	return nil, err
+}
+
+func resolveStartOffset(file *os.File, requestedOffset int64) (int64, error) {
+	stat, err := file.Stat()
+	if err != nil {
+		return 0, err
+	}
+
+	size := stat.Size()
+	if requestedOffset < 0 || requestedOffset > size {
+		return size, nil
+	}
+
+	return requestedOffset, nil
+}
+
+func readLastLines(file *os.File, limit int) ([]string, int64, error) {
+	if limit <= 0 {
+		return []string{}, 0, nil
+	}
+
+	stat, err := file.Stat()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	endOffset := stat.Size()
+	if endOffset == 0 {
+		return []string{}, 0, nil
+	}
+
+	trailingByte := make([]byte, 1)
+	_, err = file.ReadAt(trailingByte, endOffset-1)
+	if err != nil && err != io.EOF {
+		return nil, 0, err
+	}
+
+	newlinesNeeded := limit
+	if trailingByte[0] == '\n' {
+		newlinesNeeded++
+	}
+
+	startOffset := int64(0)
+	foundBoundary := false
+
+	for currentOffset := endOffset; currentOffset > 0 && !foundBoundary; {
+		chunkStart := currentOffset - tailReadChunkSize
+		if chunkStart < 0 {
+			chunkStart = 0
+		}
+
+		chunk := make([]byte, currentOffset-chunkStart)
+		_, err = file.ReadAt(chunk, chunkStart)
+		if err != nil && err != io.EOF {
+			return nil, 0, err
+		}
+
+		for idx := len(chunk) - 1; idx >= 0; idx-- {
+			if chunk[idx] != '\n' {
+				continue
+			}
+
+			newlinesNeeded--
+			if newlinesNeeded == 0 {
+				startOffset = chunkStart + int64(idx) + 1
+				foundBoundary = true
+				break
+			}
+		}
+
+		currentOffset = chunkStart
+	}
+
+	reader := io.NewSectionReader(file, startOffset, endOffset-startOffset)
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	lines := splitLogLines(data)
+	if len(lines) > limit {
+		lines = lines[len(lines)-limit:]
+	}
+
+	return lines, endOffset, nil
+}
+
+func splitLogLines(data []byte) []string {
+	if len(data) == 0 {
+		return []string{}
+	}
+
+	parts := bytes.Split(data, []byte{'\n'})
+	if len(parts) > 0 && len(parts[len(parts)-1]) == 0 {
+		parts = parts[:len(parts)-1]
+	}
+
+	lines := make([]string, len(parts))
+	for i, part := range parts {
+		lines[i] = string(part)
+	}
+
+	return lines
 }

--- a/pkg/system/logtailer.go
+++ b/pkg/system/logtailer.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -90,6 +91,10 @@ func (t LogTailer) GetChannelFromOffset(pupId string, startOffset int64) (contex
 }
 
 func (t LogTailer) GetTail(pupId string, limit int) ([]string, int64, error) {
+	if limit <= 0 {
+		return nil, 0, fmt.Errorf("Log tail limit must be greater than zero")
+	}
+
 	logFile := filepath.Join(t.config.ContainerLogDir, "pup-"+pupId)
 
 	file, err := os.Open(logFile)
@@ -142,7 +147,7 @@ func resolveStartOffset(file *os.File, requestedOffset int64) (int64, error) {
 
 func readLastLines(file *os.File, limit int) ([]string, int64, error) {
 	if limit <= 0 {
-		return []string{}, 0, nil
+		return nil, 0, fmt.Errorf("Log tail limit must be greater than zero")
 	}
 
 	stat, err := file.Stat()

--- a/pkg/system/nix/templates/pup_container.nix
+++ b/pkg/system/nix/templates/pup_container.nix
@@ -20,6 +20,8 @@ in
   systemd.services."container-log-forwarder@pup-{{.PUP_ID}}" = {
     description = "Container Log Forwarder for pup-{{.PUP_ID}}";
     after = [ "container@pup-{{.PUP_ID}}.service" ];
+    bindsTo = [ "container@pup-{{.PUP_ID}}.service" ];
+    partOf = [ "container@pup-{{.PUP_ID}}.service" ];
     requires = [ "container@pup-{{.PUP_ID}}.service" ];
     serviceConfig = {
       ExecStart = "${pkgs.bash}/bin/bash -c '${pkgs.systemd}/bin/journalctl -M pup-{{.PUP_ID}} -f --no-hostname -o short-iso >> {{.CONTAINER_LOG_DIR}}/pup-{{.PUP_ID}}'";

--- a/pkg/web/logs.go
+++ b/pkg/web/logs.go
@@ -1,0 +1,130 @@
+package web
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+const defaultLogTailLimit = 1000
+
+type logTailResponse struct {
+	Lines       []string `json:"lines"`
+	ResumeToken *string  `json:"resumeToken,omitempty"`
+}
+
+func (t api) downloadPupLog(w http.ResponseWriter, r *http.Request) {
+	pupID := r.PathValue("PupID")
+	if pupID == "" {
+		sendErrorResponse(w, http.StatusBadRequest, "Missing pup id")
+		return
+	}
+
+	if pupID == "dbx" || pupID == "dkm" {
+		sendErrorResponse(w, http.StatusBadRequest, "Journal logs cannot be downloaded from this endpoint")
+		return
+	}
+
+	if _, _, err := t.pups.GetPup(pupID); err != nil {
+		sendErrorResponse(w, http.StatusBadRequest, "Cannot find pup")
+		return
+	}
+
+	t.streamLogDownload(w, "pup-"+pupID, "pup-"+pupID+".log")
+}
+
+func (t api) downloadJobLog(w http.ResponseWriter, r *http.Request) {
+	jobID := r.PathValue("JobID")
+	if jobID == "" {
+		sendErrorResponse(w, http.StatusBadRequest, "Missing job id")
+		return
+	}
+
+	if _, err := t.dbx.JobManager.GetJob(jobID); err != nil {
+		sendErrorResponse(w, http.StatusBadRequest, "Cannot find job")
+		return
+	}
+
+	t.streamLogDownload(w, "pup-"+jobID, "job-"+jobID+".log")
+}
+
+func (t api) getPupLogTail(w http.ResponseWriter, r *http.Request) {
+	pupID := r.PathValue("PupID")
+	limit, err := parseLogTailLimit(r)
+	if err != nil {
+		sendErrorResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	lines, resumeToken, err := t.dbx.GetLogTail(pupID, limit)
+	if err != nil {
+		sendErrorResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	sendResponse(w, logTailResponse{Lines: lines, ResumeToken: resumeToken})
+}
+
+func (t api) getJobLogTail(w http.ResponseWriter, r *http.Request) {
+	jobID := r.PathValue("JobID")
+	limit, err := parseLogTailLimit(r)
+	if err != nil {
+		sendErrorResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	lines, resumeToken, err := t.dbx.GetJobLogTail(jobID, limit)
+	if err != nil {
+		sendErrorResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	sendResponse(w, logTailResponse{Lines: lines, ResumeToken: resumeToken})
+}
+
+func parseLogTailLimit(r *http.Request) (int, error) {
+	rawLimit := r.URL.Query().Get("limit")
+	if rawLimit == "" {
+		return defaultLogTailLimit, nil
+	}
+
+	limit, err := strconv.Atoi(rawLimit)
+	if err != nil {
+		return 0, errors.New("Invalid log tail limit")
+	}
+	if limit <= 0 {
+		return 0, errors.New("Log tail limit must be greater than zero")
+	}
+	if limit > defaultLogTailLimit {
+		return defaultLogTailLimit, nil
+	}
+
+	return limit, nil
+}
+
+func (t api) streamLogDownload(w http.ResponseWriter, logFileName string, downloadName string) {
+	logPath := filepath.Join(t.config.ContainerLogDir, logFileName)
+	logFile, err := os.Open(logPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			sendErrorResponse(w, http.StatusNotFound, "Log file not found")
+			return
+		}
+		sendErrorResponse(w, http.StatusInternalServerError, "Error opening log file")
+		return
+	}
+	defer logFile.Close()
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", downloadName))
+	w.Header().Set("Cache-Control", "no-store")
+
+	if _, err := io.Copy(w, logFile); err != nil {
+		log.Printf("Error streaming log file %s: %v", logFileName, err)
+	}
+}

--- a/pkg/web/logs.go
+++ b/pkg/web/logs.go
@@ -54,31 +54,27 @@ func (t api) downloadJobLog(w http.ResponseWriter, r *http.Request) {
 }
 
 func (t api) getPupLogTail(w http.ResponseWriter, r *http.Request) {
-	pupID := r.PathValue("PupID")
-	limit, err := parseLogTailLimit(r)
-	if err != nil {
-		sendErrorResponse(w, http.StatusBadRequest, err.Error())
-		return
-	}
-
-	lines, resumeToken, err := t.dbx.GetLogTail(pupID, limit)
-	if err != nil {
-		sendErrorResponse(w, http.StatusBadRequest, err.Error())
-		return
-	}
-
-	sendResponse(w, logTailResponse{Lines: lines, ResumeToken: resumeToken})
+	t.getLogTail(w, r, "PupID", t.dbx.GetLogTail)
 }
 
 func (t api) getJobLogTail(w http.ResponseWriter, r *http.Request) {
-	jobID := r.PathValue("JobID")
+	t.getLogTail(w, r, "JobID", t.dbx.GetJobLogTail)
+}
+
+func (t api) getLogTail(
+	w http.ResponseWriter,
+	r *http.Request,
+	pathValue string,
+	fetchTail func(string, int) ([]string, *string, error),
+) {
+	logID := r.PathValue(pathValue)
 	limit, err := parseLogTailLimit(r)
 	if err != nil {
 		sendErrorResponse(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
-	lines, resumeToken, err := t.dbx.GetJobLogTail(jobID, limit)
+	lines, resumeToken, err := fetchTail(logID, limit)
 	if err != nil {
 		sendErrorResponse(w, http.StatusBadRequest, err.Error())
 		return

--- a/pkg/web/rest.go
+++ b/pkg/web/rest.go
@@ -115,6 +115,10 @@ func RESTAPI(
 		"PUT /source":                         a.createSource,
 		"GET /sources/store":                  a.getStoreList,
 		"DELETE /source/{id}":                 a.deleteSource,
+		"GET /log/pup/{PupID}/download":       a.downloadPupLog,
+		"GET /log/job/{JobID}/download":       a.downloadJobLog,
+		"GET /log/pup/{PupID}/tail":           a.getPupLogTail,
+		"GET /log/job/{JobID}/tail":           a.getJobLogTail,
 		"/ws/log/pup/{PupID}":                 a.getPupLogSocket,
 		"/ws/log/job/{JobID}":                 a.getJobLogSocket,
 		"POST /system/welcome-complete":       a.setWelcomeComplete,
@@ -122,8 +126,8 @@ func RESTAPI(
 		"GET /missing-deps/{PupID}":           a.getMissingDeps,
 
 		// Sidebar preferences
-		"GET /system/sidebar-preferences":             a.getSidebarPreferences,
-		"POST /system/sidebar-preferences/pups/add":   a.addSidebarPup,
+		"GET /system/sidebar-preferences":              a.getSidebarPreferences,
+		"POST /system/sidebar-preferences/pups/add":    a.addSidebarPup,
 		"POST /system/sidebar-preferences/pups/remove": a.removeSidebarPup,
 
 		"GET /system/binary-caches":        a.getBinaryCaches,

--- a/pkg/web/websocket.go
+++ b/pkg/web/websocket.go
@@ -34,23 +34,34 @@ func (t api) getUpdateSocket(w http.ResponseWriter, r *http.Request) {
 
 // Handle incoming websocket connections for pup log output
 func (t api) getPupLogSocket(w http.ResponseWriter, r *http.Request) {
-	PupID := r.PathValue("PupID")
-	resumeToken := parseLogResumeToken(r)
-	wh, err := GetLogHandler(PupID, resumeToken, t.dbx)
-	if err != nil {
-		sendErrorResponse(w, http.StatusBadRequest, "Error establishing pup log channel")
-		return
-	}
-	wh.ServeHTTP(w, r)
+	t.getLogSocket(w, r, "PupID", func(logID string, resumeToken *string) (*websocket.Server, error) {
+		return GetLogHandler(logID, resumeToken, t.dbx)
+	}, func(err error) string {
+		return "Error establishing pup log channel"
+	})
 }
 
 // Handle incoming websocket connections for job log output
 func (t api) getJobLogSocket(w http.ResponseWriter, r *http.Request) {
-	JobID := r.PathValue("JobID")
+	t.getLogSocket(w, r, "JobID", func(logID string, resumeToken *string) (*websocket.Server, error) {
+		return GetJobLogHandler(logID, resumeToken, t.dbx)
+	}, func(err error) string {
+		return "Error establishing job log channel: " + err.Error()
+	})
+}
+
+func (t api) getLogSocket(
+	w http.ResponseWriter,
+	r *http.Request,
+	pathValue string,
+	getHandler func(string, *string) (*websocket.Server, error),
+	getErrorMessage func(error) string,
+) {
+	logID := r.PathValue(pathValue)
 	resumeToken := parseLogResumeToken(r)
-	wh, err := GetJobLogHandler(JobID, resumeToken, t.dbx)
+	wh, err := getHandler(logID, resumeToken)
 	if err != nil {
-		sendErrorResponse(w, http.StatusBadRequest, "Error establishing job log channel: "+err.Error())
+		sendErrorResponse(w, http.StatusBadRequest, getErrorMessage(err))
 		return
 	}
 	wh.ServeHTTP(w, r)

--- a/pkg/web/websocket.go
+++ b/pkg/web/websocket.go
@@ -35,7 +35,8 @@ func (t api) getUpdateSocket(w http.ResponseWriter, r *http.Request) {
 // Handle incoming websocket connections for pup log output
 func (t api) getPupLogSocket(w http.ResponseWriter, r *http.Request) {
 	PupID := r.PathValue("PupID")
-	wh, err := GetLogHandler(PupID, t.dbx)
+	resumeToken := parseLogResumeToken(r)
+	wh, err := GetLogHandler(PupID, resumeToken, t.dbx)
 	if err != nil {
 		sendErrorResponse(w, http.StatusBadRequest, "Error establishing pup log channel")
 		return
@@ -46,7 +47,8 @@ func (t api) getPupLogSocket(w http.ResponseWriter, r *http.Request) {
 // Handle incoming websocket connections for job log output
 func (t api) getJobLogSocket(w http.ResponseWriter, r *http.Request) {
 	JobID := r.PathValue("JobID")
-	wh, err := GetJobLogHandler(JobID, t.dbx)
+	resumeToken := parseLogResumeToken(r)
+	wh, err := GetJobLogHandler(JobID, resumeToken, t.dbx)
 	if err != nil {
 		sendErrorResponse(w, http.StatusBadRequest, "Error establishing job log channel: "+err.Error())
 		return
@@ -58,4 +60,13 @@ func (t api) getJobLogSocket(w http.ResponseWriter, r *http.Request) {
 func (t api) getJobsSocket(w http.ResponseWriter, r *http.Request) {
 	wh := t.GetJobsHandler()
 	wh.ServeHTTP(w, r)
+}
+
+func parseLogResumeToken(r *http.Request) *string {
+	rawResumeToken := r.URL.Query().Get("resumeToken")
+	if rawResumeToken == "" {
+		return nil
+	}
+
+	return &rawResumeToken
 }

--- a/pkg/web/websocket_activities.go
+++ b/pkg/web/websocket_activities.go
@@ -33,9 +33,9 @@ func (t api) GetJobsHandler() *websocket.Server {
 
 // GetJobLogHandler creates a WebSocket handler for streaming job logs
 // Uses the same log streaming mechanism as pup logs (ActionLogger)
-func GetJobLogHandler(JobID string, dbx dogeboxd.Dogeboxd) (*websocket.Server, error) {
+func GetJobLogHandler(JobID string, resumeToken *string, dbx dogeboxd.Dogeboxd) (*websocket.Server, error) {
 	// Get log channel for this job (same system as pup logs)
-	cancel, logChan, err := dbx.GetJobLogChannel(JobID)
+	cancel, logChan, err := dbx.GetJobLogChannel(JobID, resumeToken)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/web/websocket_logger.go
+++ b/pkg/web/websocket_logger.go
@@ -7,8 +7,8 @@ import (
 	"golang.org/x/net/websocket"
 )
 
-func GetLogHandler(PupID string, dbx dogeboxd.Dogeboxd) (*websocket.Server, error) {
-	cancel, logChan, err := dbx.GetLogChannel(PupID)
+func GetLogHandler(PupID string, resumeToken *string, dbx dogeboxd.Dogeboxd) (*websocket.Server, error) {
+	cancel, logChan, err := dbx.GetLogChannel(PupID, resumeToken)
 	if err != nil {
 		fmt.Println("ERR", err)
 		return nil, err


### PR DESCRIPTION
This fixes an issue where pups with noisy logs would have poor performance both in the initial load of the logs page (5+ seconds) and continuous display of logs (browser may crash as logs in memory increases indefinitely)

**New functionality:**
- Added fast tail endpoints for pup and job logs so initial hydration does not scan full log files (downloads latest 1000 lines)
- Hydration hands over to live logs using a resume token to avoid gaps
- Added full-log download support
- Bound container log forwarders to the pup container so live logs recover after a pup is restarted
- Updated Makefile to handling case where node_modules exist but are for a different architecture (which can happen if they're installed for Linux within orb, but host machine is running MacOS)

Related frontend PR: https://github.com/Dogebox-WG/dpanel/pull/216