### PR TITLE
fix: skip disabled pups cleanly during nix rebuilds

### DIFF
--- a/cmd/dbx/cmd/can-pup-start.go
+++ b/cmd/dbx/cmd/can-pup-start.go
@@ -84,15 +84,19 @@ var canPupStartCmd = &cobra.Command{
 			os.Exit(0)
 		}
 
-		log.Println("Can start: false")
-		utils.ExitBad(systemd)
+		if pupState, ok := pupManager.GetStateMap()[pupId]; ok && !pupState.Enabled {
+			log.Println("Can start: false (pup is disabled)")
+		} else {
+			log.Println("Can start: false")
+		}
+		utils.ExitConditionNotMet(systemd)
 	},
 }
 
 func init() {
 	canPupStartCmd.Flags().StringP("pup-id", "p", "", "id of pup to check")
 	canPupStartCmd.Flags().StringP("data-dir", "d", "/opt/dogebox", "dogebox data dir")
-	canPupStartCmd.Flags().BoolP("systemd", "", false, "Exits with 255 instead of 1 if in recovery mode.")
+	canPupStartCmd.Flags().BoolP("systemd", "", false, "Uses systemd-specific exit codes for ExecCondition.")
 	canPupStartCmd.MarkFlagRequired("data-dir")
 	canPupStartCmd.MarkFlagRequired("pup-id")
 	rootCmd.AddCommand(canPupStartCmd)

--- a/cmd/dbx/cmd/can-pup-start.go
+++ b/cmd/dbx/cmd/can-pup-start.go
@@ -89,7 +89,7 @@ var canPupStartCmd = &cobra.Command{
 		} else {
 			log.Println("Can start: false")
 		}
-		utils.ExitConditionNotMet(systemd)
+		os.Exit(1)
 	},
 }
 

--- a/cmd/dbx/utils/utils.go
+++ b/cmd/dbx/utils/utils.go
@@ -10,3 +10,7 @@ func ExitBad(isSystemd bool) {
 
 	os.Exit(1)
 }
+
+func ExitConditionNotMet(_ bool) {
+	os.Exit(1)
+}

--- a/cmd/dbx/utils/utils.go
+++ b/cmd/dbx/utils/utils.go
@@ -10,7 +10,3 @@ func ExitBad(isSystemd bool) {
 
 	os.Exit(1)
 }
-
-func ExitConditionNotMet(_ bool) {
-	os.Exit(1)
-}


### PR DESCRIPTION
Treat disabled pups as a normal ExecCondition miss instead of a systemd error so rebuilds are not marked as failed

See issue for more details: https://github.com/Dogebox-WG/dogeboxd/issues/205