### PR TITLE
Nix cache update job efficiency improvements

### DIFF
--- a/pkg/dogeboxd.go
+++ b/pkg/dogeboxd.go
@@ -159,6 +159,12 @@ func (t Dogeboxd) Run(started, stopped chan bool, stop chan context.Context) err
 					if !ok {
 						break dance
 					}
+					// Queue management: skip a nix cache update if the next queued
+					// job is already a nix cache update.
+					if t.shouldSkipJob(j) {
+						break dance
+					}
+
 					j.Start = time.Now() // start the job timer
 
 					// Create job record for tracking (skip routine operations like metrics)
@@ -306,6 +312,32 @@ func (t *Dogeboxd) enqueue(j Job) {
 	t.queue.jobQLock.Lock()
 	defer t.queue.jobQLock.Unlock()
 	t.queue.jobQueue = append(t.queue.jobQueue, j)
+}
+
+func (t Dogeboxd) shouldSkipJob(j Job) bool {
+	if _, ok := j.A.(UpdateNixCache); ok {
+		return t.shouldSkipQueuedNixCacheJob()
+	}
+
+	return false
+}
+
+func (t Dogeboxd) shouldSkipQueuedNixCacheJob() bool {
+	t.queue.jobQLock.Lock()
+	defer t.queue.jobQLock.Unlock()
+
+	if len(t.queue.jobQueue) == 0 {
+		return false
+	}
+
+	lastQueued := t.queue.jobQueue[len(t.queue.jobQueue)-1]
+	if _, ok := lastQueued.A.(UpdateNixCache); !ok {
+		return false
+	}
+
+	// Intentionally ignore the currently running job. Only skip when the
+	// next queued job is already a nix cache update.
+	return true
 }
 
 // Add an Action to the Action queue, returns a unique ID

--- a/pkg/dogeboxd_queue_test.go
+++ b/pkg/dogeboxd_queue_test.go
@@ -1,0 +1,40 @@
+package dogeboxd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueueManagementSkipsAdjacentNixCacheUpdates(t *testing.T) {
+	dbx := Dogeboxd{
+		queue: &syncQueue{
+			jobQueue: []Job{
+				{ID: "cache-1", A: UpdateNixCache{}},
+			},
+		},
+	}
+
+	assert.True(t, dbx.shouldSkipJob(Job{ID: "cache-2", A: UpdateNixCache{}}))
+}
+
+func TestQueueManagementKeepsSeparatedNixCacheUpdates(t *testing.T) {
+	dbx := Dogeboxd{
+		queue: &syncQueue{
+			jobQueue: []Job{
+				{ID: "cache-1", A: UpdateNixCache{}},
+				{ID: "job-2", A: UpdateTimezone{Timezone: "UTC"}},
+			},
+		},
+	}
+
+	assert.False(t, dbx.shouldSkipJob(Job{ID: "cache-3", A: UpdateNixCache{}}))
+}
+
+func TestQueueManagementIgnoresRunningNixCacheJob(t *testing.T) {
+	dbx := Dogeboxd{
+		queue: &syncQueue{},
+	}
+
+	assert.False(t, dbx.shouldSkipJob(Job{ID: "cache-1", A: UpdateNixCache{}}))
+}

--- a/pkg/sys.go
+++ b/pkg/sys.go
@@ -392,6 +392,7 @@ type NixManager interface {
 
 	NewPatch(log SubLogger) NixPatch
 
+	GetConfigValueContext(ctx context.Context, configItem string) (string, error)
 	GetConfigValue(configItem string) (string, error)
 }
 

--- a/pkg/system/nix/nix.go
+++ b/pkg/system/nix/nix.go
@@ -1,6 +1,7 @@
 package nix
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -390,6 +391,10 @@ func GetRunningFlakePath() (string, error) {
 }
 
 func (nm nixManager) GetConfigValue(configItem string) (string, error) {
+	return nm.GetConfigValueContext(context.Background(), configItem)
+}
+
+func (nm nixManager) GetConfigValueContext(ctx context.Context, configItem string) (string, error) {
 	flakePath, err := GetRunningFlakePath()
 	if err != nil {
 		return "", err
@@ -404,29 +409,38 @@ func (nm nixManager) GetConfigValue(configItem string) (string, error) {
 	// rather than raw or JSON, as this stringifies the errors rather than
 	// failing the command.
 	if !strings.Contains(configItem, ".") {
-		cmd := exec.Command("nix", "eval", expr, "--impure")
+		cmd := exec.CommandContext(ctx, "nix", "eval", expr, "--impure")
 		cmd.Env = cmdEnv
 		err := cmd.Run()
 		if err != nil {
+			if ctx.Err() != nil {
+				return "", fmt.Errorf("timed out waiting for nix config %q: %w", configItem, ctx.Err())
+			}
 			return "", err
 		}
 		return "", nil
 	}
 
 	// Fast path: try `--raw` first (works when the option evaluates to a string).
-	cmd := exec.Command("nix", "eval", "--raw", expr, "--impure")
+	cmd := exec.CommandContext(ctx, "nix", "eval", "--raw", expr, "--impure")
 	cmd.Env = cmdEnv
 	stdout, rawErr := cmd.Output()
 	if rawErr == nil {
 		return strings.TrimSpace(string(stdout)), nil
 	}
+	if ctx.Err() != nil {
+		return "", fmt.Errorf("timed out waiting for nix config %q: %w", configItem, ctx.Err())
+	}
 
 	// Fallback: evaluate as JSON, then only return the string if the evaluated
 	// value is actually a string.
-	cmd = exec.Command("nix", "eval", "--json", expr, "--impure")
+	cmd = exec.CommandContext(ctx, "nix", "eval", "--json", expr, "--impure")
 	cmd.Env = cmdEnv
 	stdout, jsonErr := cmd.Output()
 	if jsonErr != nil {
+		if ctx.Err() != nil {
+			return "", fmt.Errorf("timed out waiting for nix config %q: %w", configItem, ctx.Err())
+		}
 		return "", fmt.Errorf("nix eval for %q failed (raw error: %w, json error: %v)", configItem, rawErr, jsonErr)
 	}
 

--- a/pkg/system/updater.go
+++ b/pkg/system/updater.go
@@ -53,6 +53,8 @@ type SystemUpdater struct {
 	dkm        dogeboxd.DKMManager
 }
 
+var nixCacheUpdateTimeout = 60 * time.Second
+
 func (t SystemUpdater) Run(started, stopped chan bool, stop chan context.Context) error {
 	go func() {
 		go func() {
@@ -205,7 +207,7 @@ func (t SystemUpdater) Run(started, stopped chan bool, stop chan context.Context
 					case dogeboxd.UpdateNixCache:
 						err := t.updateNixCache(j)
 						if err != nil {
-							j.Err = "Failed to update nix cache"
+							j.Err = err.Error()
 						}
 						t.done <- j
 
@@ -739,15 +741,17 @@ func (t SystemUpdater) updateKeymap(a dogeboxd.UpdateKeymap, log dogeboxd.SubLog
 func (t SystemUpdater) updateNixCache(j dogeboxd.Job) error {
 	log := j.Logger.Step("update nix cache")
 	log.Log("Updating nix cache...")
+	ctx, cancel := context.WithTimeout(context.Background(), nixCacheUpdateTimeout)
+	defer cancel()
 
 	// These two sections should be a balance between pre-populating what
 	// we need and not eating too many resources to fetch.
-	if _, err := t.nix.GetConfigValue("console"); err != nil {
+	if _, err := t.nix.GetConfigValueContext(ctx, "console"); err != nil {
 		log.Errf("Failed to get console section from nix config: %v", err)
 		return err
 	}
 
-	if _, err := t.nix.GetConfigValue("time"); err != nil {
+	if _, err := t.nix.GetConfigValueContext(ctx, "time"); err != nil {
 		log.Errf("Failed to get time section from nix config: %v", err)
 		return err
 	}

--- a/pkg/system/updater_nix_cache_test.go
+++ b/pkg/system/updater_nix_cache_test.go
@@ -1,0 +1,97 @@
+package system
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	dogeboxd "github.com/Dogebox-WG/dogeboxd/pkg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testNixManager struct {
+	calls   []string
+	blockOn string
+}
+
+func (t *testNixManager) InitSystem(patch dogeboxd.NixPatch, dbxState dogeboxd.DogeboxState) {}
+
+func (t *testNixManager) UpdateIncludesFile(patch dogeboxd.NixPatch, pups dogeboxd.PupManager) {}
+
+func (t *testNixManager) WritePupFile(patch dogeboxd.NixPatch, state dogeboxd.PupState, dbxState dogeboxd.DogeboxState) {}
+
+func (t *testNixManager) RemovePupFile(patch dogeboxd.NixPatch, pupID string) {}
+
+func (t *testNixManager) UpdateSystemContainerConfiguration(patch dogeboxd.NixPatch) {}
+
+func (t *testNixManager) UpdateFirewallRules(patch dogeboxd.NixPatch, dbxState dogeboxd.DogeboxState) {}
+
+func (t *testNixManager) UpdateNetwork(patch dogeboxd.NixPatch, values dogeboxd.NixNetworkTemplateValues) {}
+
+func (t *testNixManager) UpdateSystem(patch dogeboxd.NixPatch, values dogeboxd.NixSystemTemplateValues) {}
+
+func (t *testNixManager) UpdateStorageOverlay(patch dogeboxd.NixPatch, partitionName string) {}
+
+func (t *testNixManager) RebuildBoot(log dogeboxd.SubLogger) error { return nil }
+
+func (t *testNixManager) Rebuild(log dogeboxd.SubLogger) error { return nil }
+
+func (t *testNixManager) NewPatch(log dogeboxd.SubLogger) dogeboxd.NixPatch { return nil }
+
+func (t *testNixManager) GetConfigValue(configItem string) (string, error) {
+	return t.GetConfigValueContext(context.Background(), configItem)
+}
+
+func (t *testNixManager) GetConfigValueContext(ctx context.Context, configItem string) (string, error) {
+	t.calls = append(t.calls, configItem)
+	if configItem == t.blockOn {
+		<-ctx.Done()
+		return "", fmt.Errorf("timed out waiting for nix config %q: %w", configItem, ctx.Err())
+	}
+
+	return configItem, nil
+}
+
+func TestUpdateNixCacheWarmsExpectedConfigSections(t *testing.T) {
+	updater := SystemUpdater{
+		nix: &testNixManager{},
+	}
+
+	err := updater.updateNixCache(testNixCacheJob())
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"console", "time"}, updater.nix.(*testNixManager).calls)
+}
+
+func TestUpdateNixCacheTimesOut(t *testing.T) {
+	originalTimeout := nixCacheUpdateTimeout
+	nixCacheUpdateTimeout = 20 * time.Millisecond
+	t.Cleanup(func() {
+		nixCacheUpdateTimeout = originalTimeout
+	})
+
+	fakeNix := &testNixManager{blockOn: "console"}
+	updater := SystemUpdater{
+		nix: fakeNix,
+	}
+
+	err := updater.updateNixCache(testNixCacheJob())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, []string{"console"}, fakeNix.calls)
+}
+
+func testNixCacheJob() dogeboxd.Job {
+	job := dogeboxd.Job{
+		ID: "job-nix-cache",
+		A:  dogeboxd.UpdateNixCache{},
+	}
+	job.Logger = dogeboxd.NewActionLogger(job, "", dogeboxd.Dogeboxd{
+		Changes: make(chan dogeboxd.Change, 8),
+	})
+
+	return job
+}


### PR DESCRIPTION
Added a 60 second timeout and a skip for when the next queued job is already a nix cache update