### PR TITLE
Pup Source Improvements - Backend

### DIFF
--- a/pkg/sources/disk.go
+++ b/pkg/sources/disk.go
@@ -59,6 +59,13 @@ func (r ManifestSourceDisk) Config() dogeboxd.ManifestSourceConfiguration {
 }
 
 func (r ManifestSourceDisk) List(_ bool) (dogeboxd.ManifestSourceList, error) {
+	if _, err := os.Stat(r.config.Location); err != nil {
+		if os.IsNotExist(err) {
+			return dogeboxd.ManifestSourceList{}, fmt.Errorf("source path does not exist: %s", r.config.Location)
+		}
+		return dogeboxd.ManifestSourceList{}, fmt.Errorf("failed to access source path %s: %w", r.config.Location, err)
+	}
+
 	dogeboxPath := filepath.Join(r.config.Location, "dogebox.json")
 
 	pupLocations := []string{}

--- a/pkg/sources/git.go
+++ b/pkg/sources/git.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	dogeboxd "github.com/Dogebox-WG/dogeboxd/pkg"
@@ -311,17 +310,7 @@ func (r *ManifestSourceGit) List(ignoreCache bool) (dogeboxd.ManifestSourceList,
 		return r._cache, nil
 	}
 
-	repo, err := git.Clone(memory.NewStorage(), memfs.New(), &git.CloneOptions{
-		URL:          r.config.Location,
-		Depth:        1,
-		SingleBranch: true,
-		Tags:         git.AllTags,
-	})
-	if err != nil {
-		return dogeboxd.ManifestSourceList{}, err
-	}
-
-	iter, err := repo.Tags()
+	tags, err := r.GetAllGitTags(r.config.Location)
 	if err != nil {
 		return dogeboxd.ManifestSourceList{}, err
 	}
@@ -332,35 +321,37 @@ func (r *ManifestSourceGit) List(ignoreCache bool) (dogeboxd.ManifestSourceList,
 		err     error
 	}
 
-	resultChan := make(chan TagResult)
-	var tagCount int
-
-	err = iter.ForEach(func(p *plumbing.Reference) error {
-		tagRef := string(p.Name())
-		tagName := strings.Replace(tagRef, "refs/tags/", "", -1)
+	tagVersions := []string{}
+	for _, tagName := range tags {
 		if semver.IsValid(tagName) {
-			tagCount++
-			go func(ref, version string) {
-				entries, err := r.ensureTagValidAndGetPups(ref)
-				resultChan <- TagResult{
-					version: version,
-					entries: entries,
-					err:     err,
-				}
-			}(tagRef, tagName)
+			tagVersions = append(tagVersions, tagName)
 		}
+	}
 
-		return nil
-	})
-	if err != nil {
-		return dogeboxd.ManifestSourceList{}, err
+	resultChan := make(chan TagResult, len(tagVersions))
+	validationSlots := make(chan struct{}, 4)
+
+	for _, version := range tagVersions {
+		go func(version string) {
+			validationSlots <- struct{}{}
+			defer func() {
+				<-validationSlots
+			}()
+
+			entries, err := r.ensureTagValidAndGetPups("refs/tags/" + version)
+			resultChan <- TagResult{
+				version: version,
+				entries: entries,
+				err:     err,
+			}
+		}(version)
 	}
 
 	validPups := []dogeboxd.ManifestSourcePup{}
 
 	ownerRepo, isGitHub := pup.ParseGitHubOwnerRepo(r.config.Location)
 
-	for i := 0; i < tagCount; i++ {
+	for i := 0; i < len(tagVersions); i++ {
 		result := <-resultChan
 		if result.err != nil {
 			log.Printf("Error validating tag %s: %v", result.version, result.err)

--- a/pkg/web/store.go
+++ b/pkg/web/store.go
@@ -85,24 +85,6 @@ func (t api) getStoreList(w http.ResponseWriter, r *http.Request) {
 			pups[availablePup.Name] = pupEntry
 		}
 
-		// Override any entry in the listing with what we actually have installed.
-		// We want to show that is _actually_ installed, rather than what might have been removed or updated underneath us.
-		// nb. We don't let you remove a source if you have a pup installed from it, so this should be safe here.
-		for _, installedPup := range t.dbx.Pups.GetStateMap() {
-			if installedPup.Source.Location == entry.Config.Location && installedPup.Source.Name == entry.Config.Name {
-				if _, ok := pups[installedPup.Manifest.Meta.Name]; !ok {
-					pups[installedPup.Manifest.Meta.Name] = StoreListSourceEntryPup{
-						Versions: map[string]dogeboxd.PupManifest{},
-					}
-				}
-
-				pupEntry := pups[installedPup.Manifest.Meta.Name]
-				pupEntry.Versions[installedPup.Version] = installedPup.Manifest
-				pupEntry.LatestVersion = installedPup.Version
-				pups[installedPup.Manifest.Meta.Name] = pupEntry
-			}
-		}
-
 		response[k] = StoreListSourceEntry{
 			Name:        entry.Config.Name,
 			Description: entry.Config.Description,


### PR DESCRIPTION
### Pup source refreshes now only return pups that still exist on the source.

This makes `/sources/store` reflect the current source contents instead of mixing in locally installed pups

### New features

* Stop re-adding locally installed pups into `/sources/store` when the source no longer lists them
* Let clients distinguish between pups that are installed locally and pups that are still available from the source
* Improved efficiency of git tag validation during source refreshes
* Added specific error when source path doesn't exist

**Frontend PR** - [Dogebox-WG/dpanel#246](https://github.com/Dogebox-WG/dpanel/pull/246)