### PR TITLE
Log Prefix Differentiation

### DIFF
--- a/cmd/dogeboxd/server.go
+++ b/cmd/dogeboxd/server.go
@@ -71,7 +71,7 @@ func (t server) Start() {
 
 	systemUpdater := system.NewSystemUpdater(t.config, networkManager, nixManager, sourceManager, pups, t.sm, lifecycleManager, dkm)
 	journalReader := system.NewJournalReader(t.config)
-	logtailer := system.NewLogTailer(t.config)
+	logtailer := system.NewLogTailer()
 
 	/* ----------------------------------------------------------------------- */
 	// Set up PupManager and load the state for all installed pups

--- a/pkg/action_logger.go
+++ b/pkg/action_logger.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"os/exec"
-	"path/filepath"
 	"time"
 
 	"gopkg.in/natefinch/lumberjack.v2"
@@ -95,7 +94,7 @@ func (t *stepLogger) writeToLogFile(msg string) {
 	if t.l.dbx.config != nil {
 		logDir := t.l.dbx.config.ContainerLogDir
 		if logDir != "" {
-			logFile := filepath.Join(logDir, "pup-"+t.l.Job.ID)
+			logFile := t.l.dbx.config.JobLogPath(t.l.Job.ID)
 
 			// Use lumberjack for log rotation
 			writer := &lumberjack.Logger{

--- a/pkg/action_logger_test.go
+++ b/pkg/action_logger_test.go
@@ -2,7 +2,9 @@ package dogeboxd
 
 import (
 	"bytes"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -563,4 +565,24 @@ func TestActionLoggerProgressOver100(t *testing.T) {
 	step.Progress(150).Log("Message")
 
 	assert.Equal(t, 150, step.progress)
+}
+
+func TestActionLoggerWritesJobLogsToJobPrefixedFile(t *testing.T) {
+	tempDir := t.TempDir()
+	job := createTestJob("InstallPup")
+	testDBX := &Dogeboxd{
+		Changes: make(chan Change, 100),
+		config:  &ServerConfig{ContainerLogDir: tempDir},
+	}
+	logger := NewActionLogger(job, "test-pup-id", *testDBX)
+
+	logger.Step("test-step").Log("Test message")
+
+	jobLogPath := filepath.Join(tempDir, "job-"+job.ID)
+	logData, err := os.ReadFile(jobLogPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(logData), "Test message")
+
+	_, err = os.Stat(filepath.Join(tempDir, "pup-"+job.ID))
+	assert.ErrorIs(t, err, os.ErrNotExist)
 }

--- a/pkg/dogeboxd.go
+++ b/pkg/dogeboxd.go
@@ -856,21 +856,47 @@ var allowedJournalServices = map[string]string{
 	"dkm": "dkm.service",
 }
 
-func (t Dogeboxd) GetLogChannel(PupID string, resumeToken *string) (context.CancelFunc, chan string, error) {
+type logSource struct {
+	journalService string
+	filePath       string
+}
+
+func (s logSource) usesJournal() bool {
+	return s.journalService != ""
+}
+
+func (t Dogeboxd) resolvePupLogSource(PupID string) (logSource, error) {
 	// We read dogeboxd and dkm from the host systemd journal,
 	// and read everything else (pups) from the container logs we export.
 	service, ok := allowedJournalServices[PupID]
 	if ok {
-		if resumeToken != nil {
-			return t.JournalReader.GetJournalChannelFromCursor(service, *resumeToken)
-		}
-		return t.JournalReader.GetJournalChannel(service)
+		return logSource{journalService: service}, nil
 	}
 
 	// Check that we've actually got a valid pup id.
 	_, _, err := t.Pups.GetPup(PupID)
 	if err != nil {
-		return nil, nil, err
+		return logSource{}, err
+	}
+
+	return logSource{filePath: t.config.PupLogPath(PupID)}, nil
+}
+
+func (t Dogeboxd) resolveJobLogSource(JobID string) (logSource, error) {
+	_, err := t.JobManager.GetJob(JobID)
+	if err != nil {
+		return logSource{}, fmt.Errorf("job not found: %s", JobID)
+	}
+
+	return logSource{filePath: t.config.JobLogPath(JobID)}, nil
+}
+
+func (t Dogeboxd) getLogChannel(source logSource, resumeToken *string) (context.CancelFunc, chan string, error) {
+	if source.usesJournal() {
+		if resumeToken != nil {
+			return t.JournalReader.GetJournalChannelFromCursor(source.journalService, *resumeToken)
+		}
+		return t.JournalReader.GetJournalChannel(source.journalService)
 	}
 
 	if resumeToken != nil {
@@ -878,72 +904,65 @@ func (t Dogeboxd) GetLogChannel(PupID string, resumeToken *string) (context.Canc
 		if err != nil {
 			return nil, nil, err
 		}
-		return t.logtailer.GetChannelFromOffset(PupID, offset)
+		return t.logtailer.GetChannelFromOffset(source.filePath, offset)
 	}
 
-	return t.logtailer.GetChannel(PupID)
+	return t.logtailer.GetChannel(source.filePath)
 }
 
-func (t Dogeboxd) GetLogTail(PupID string, limit int) ([]string, *string, error) {
+func (t Dogeboxd) getLogTail(source logSource, limit int) ([]string, *string, error) {
 	if limit <= 0 {
 		return nil, nil, fmt.Errorf("Log tail limit must be greater than zero")
 	}
 
-	service, ok := allowedJournalServices[PupID]
-	if ok {
-		lines, resumeToken, err := t.JournalReader.GetJournalTail(service, limit)
-		return lines, resumeToken, err
+	if source.usesJournal() {
+		return t.JournalReader.GetJournalTail(source.journalService, limit)
 	}
 
-	_, _, err := t.Pups.GetPup(PupID)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	lines, resumeToken, err := t.logtailer.GetTail(PupID, limit)
+	lines, resumeToken, err := t.logtailer.GetTail(source.filePath, limit)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	return lines, logOffsetResumeToken(resumeToken), nil
+}
+
+func (t Dogeboxd) GetLogChannel(PupID string, resumeToken *string) (context.CancelFunc, chan string, error) {
+	source, err := t.resolvePupLogSource(PupID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return t.getLogChannel(source, resumeToken)
+}
+
+func (t Dogeboxd) GetLogTail(PupID string, limit int) ([]string, *string, error) {
+	source, err := t.resolvePupLogSource(PupID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return t.getLogTail(source, limit)
 }
 
 // GetJobLogChannel returns a log channel for a specific job
 // Streams logs from the job's ActionLogger in real-time (same system as pup logs)
 func (t Dogeboxd) GetJobLogChannel(JobID string, resumeToken *string) (context.CancelFunc, chan string, error) {
-	// Verify job exists
-	_, err := t.JobManager.GetJob(JobID)
-	if err != nil {
-		return nil, nil, fmt.Errorf("job not found: %s", JobID)
-	}
-
-	if resumeToken != nil {
-		offset, err := parseLogOffsetResumeToken(*resumeToken)
-		if err != nil {
-			return nil, nil, err
-		}
-		return t.logtailer.GetChannelFromOffset(JobID, offset)
-	}
-
-	return t.logtailer.GetChannel(JobID)
-}
-
-func (t Dogeboxd) GetJobLogTail(JobID string, limit int) ([]string, *string, error) {
-	if limit <= 0 {
-		return nil, nil, fmt.Errorf("Log tail limit must be greater than zero")
-	}
-
-	_, err := t.JobManager.GetJob(JobID)
-	if err != nil {
-		return nil, nil, fmt.Errorf("job not found: %s", JobID)
-	}
-
-	lines, resumeToken, err := t.logtailer.GetTail(JobID, limit)
+	source, err := t.resolveJobLogSource(JobID)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return lines, logOffsetResumeToken(resumeToken), nil
+	return t.getLogChannel(source, resumeToken)
+}
+
+func (t Dogeboxd) GetJobLogTail(JobID string, limit int) ([]string, *string, error) {
+	source, err := t.resolveJobLogSource(JobID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return t.getLogTail(source, limit)
 }
 
 func parseLogOffsetResumeToken(resumeToken string) (int64, error) {

--- a/pkg/log_paths.go
+++ b/pkg/log_paths.go
@@ -1,0 +1,26 @@
+package dogeboxd
+
+import (
+	"path/filepath"
+)
+
+const (
+	pupLogPrefix = "pup-"
+	jobLogPrefix = "job-"
+)
+
+func (c ServerConfig) PupLogFileName(pupID string) string {
+	return pupLogPrefix + pupID
+}
+
+func (c ServerConfig) PupLogPath(pupID string) string {
+	return filepath.Join(c.ContainerLogDir, c.PupLogFileName(pupID))
+}
+
+func (c ServerConfig) JobLogFileName(jobID string) string {
+	return jobLogPrefix + jobID
+}
+
+func (c ServerConfig) JobLogPath(jobID string) string {
+	return filepath.Join(c.ContainerLogDir, c.JobLogFileName(jobID))
+}

--- a/pkg/log_paths_test.go
+++ b/pkg/log_paths_test.go
@@ -1,0 +1,178 @@
+package dogeboxd
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubLogTailer struct {
+	lastChannelPath   string
+	lastChannelOffset int64
+	lastTailPath      string
+	lastTailLimit     int
+}
+
+func (t *stubLogTailer) GetChannel(path string) (context.CancelFunc, chan string, error) {
+	t.lastChannelPath = path
+	return func() {}, make(chan string), nil
+}
+
+func (t *stubLogTailer) GetChannelFromOffset(path string, offset int64) (context.CancelFunc, chan string, error) {
+	t.lastChannelPath = path
+	t.lastChannelOffset = offset
+	return func() {}, make(chan string), nil
+}
+
+func (t *stubLogTailer) GetTail(path string, limit int) ([]string, int64, error) {
+	t.lastTailPath = path
+	t.lastTailLimit = limit
+	return []string{filepath.Base(path)}, 42, nil
+}
+
+type stubJournalReader struct {
+	lastChannelService string
+	lastChannelCursor  string
+	lastTailService    string
+	lastTailLimit      int
+}
+
+func (t *stubJournalReader) GetJournalChannel(service string) (context.CancelFunc, chan string, error) {
+	t.lastChannelService = service
+	return func() {}, make(chan string), nil
+}
+
+func (t *stubJournalReader) GetJournalChannelFromCursor(service string, cursor string) (context.CancelFunc, chan string, error) {
+	t.lastChannelService = service
+	t.lastChannelCursor = cursor
+	return func() {}, make(chan string), nil
+}
+
+func (t *stubJournalReader) GetJournalTail(service string, limit int) ([]string, *string, error) {
+	t.lastTailService = service
+	t.lastTailLimit = limit
+	resumeToken := "journal-cursor"
+	return []string{service}, &resumeToken, nil
+}
+
+func TestDogeboxdGetJobLogTailUsesJobPath(t *testing.T) {
+	config := &ServerConfig{ContainerLogDir: t.TempDir()}
+
+	jm, err := setupTestJobManager()
+	require.NoError(t, err)
+
+	logtailer := &stubLogTailer{}
+	dbx := Dogeboxd{
+		JobManager: jm,
+		config:     config,
+		logtailer:  logtailer,
+	}
+
+	job := createTestJob("InstallPup")
+	_, err = jm.CreateJobRecord(job)
+	require.NoError(t, err)
+
+	lines, resumeToken, err := dbx.GetJobLogTail(job.ID, 10)
+	require.NoError(t, err)
+	require.NotNil(t, resumeToken)
+	assert.Equal(t, []string{filepath.Base(config.JobLogPath(job.ID))}, lines)
+	assert.Equal(t, config.JobLogPath(job.ID), logtailer.lastTailPath)
+	assert.Equal(t, 10, logtailer.lastTailLimit)
+}
+
+func TestDogeboxdGetJobLogChannelUsesJobPath(t *testing.T) {
+	config := &ServerConfig{ContainerLogDir: t.TempDir()}
+
+	jm, err := setupTestJobManager()
+	require.NoError(t, err)
+
+	logtailer := &stubLogTailer{}
+	dbx := Dogeboxd{
+		JobManager: jm,
+		config:     config,
+		logtailer:  logtailer,
+	}
+
+	job := createTestJob("InstallPup")
+	_, err = jm.CreateJobRecord(job)
+	require.NoError(t, err)
+
+	t.Run("without resume token", func(t *testing.T) {
+		cancel, channel, err := dbx.GetJobLogChannel(job.ID, nil)
+		require.NoError(t, err)
+		require.NotNil(t, cancel)
+		require.NotNil(t, channel)
+		assert.Equal(t, config.JobLogPath(job.ID), logtailer.lastChannelPath)
+		assert.Equal(t, int64(0), logtailer.lastChannelOffset)
+	})
+
+	t.Run("with resume token", func(t *testing.T) {
+		resumeToken := "123"
+		cancel, channel, err := dbx.GetJobLogChannel(job.ID, &resumeToken)
+		require.NoError(t, err)
+		require.NotNil(t, cancel)
+		require.NotNil(t, channel)
+		assert.Equal(t, config.JobLogPath(job.ID), logtailer.lastChannelPath)
+		assert.Equal(t, int64(123), logtailer.lastChannelOffset)
+	})
+}
+
+func TestDogeboxdGetLogChannelUsesJournalSource(t *testing.T) {
+	journalReader := &stubJournalReader{}
+	logtailer := &stubLogTailer{}
+	dbx := Dogeboxd{
+		JournalReader: journalReader,
+		logtailer:     logtailer,
+		config:        &ServerConfig{ContainerLogDir: t.TempDir()},
+	}
+
+	t.Run("without resume token", func(t *testing.T) {
+		cancel, channel, err := dbx.GetLogChannel("dbx", nil)
+		require.NoError(t, err)
+		require.NotNil(t, cancel)
+		require.NotNil(t, channel)
+		assert.Equal(t, "dogeboxd.service", journalReader.lastChannelService)
+		assert.Equal(t, "", logtailer.lastChannelPath)
+	})
+
+	t.Run("with resume token", func(t *testing.T) {
+		resumeToken := "cursor-123"
+		cancel, channel, err := dbx.GetLogChannel("dkm", &resumeToken)
+		require.NoError(t, err)
+		require.NotNil(t, cancel)
+		require.NotNil(t, channel)
+		assert.Equal(t, "dkm.service", journalReader.lastChannelService)
+		assert.Equal(t, "cursor-123", journalReader.lastChannelCursor)
+		assert.Equal(t, "", logtailer.lastChannelPath)
+	})
+}
+
+func TestDogeboxdGetLogTailUsesJournalSource(t *testing.T) {
+	journalReader := &stubJournalReader{}
+	logtailer := &stubLogTailer{}
+	dbx := Dogeboxd{
+		JournalReader: journalReader,
+		logtailer:     logtailer,
+		config:        &ServerConfig{ContainerLogDir: t.TempDir()},
+	}
+
+	lines, resumeToken, err := dbx.GetLogTail("dbx", 25)
+	require.NoError(t, err)
+	require.NotNil(t, resumeToken)
+	assert.Equal(t, []string{"dogeboxd.service"}, lines)
+	assert.Equal(t, "dogeboxd.service", journalReader.lastTailService)
+	assert.Equal(t, 25, journalReader.lastTailLimit)
+	assert.Equal(t, "", logtailer.lastTailPath)
+}
+
+func TestServerConfigLogFileNames(t *testing.T) {
+	config := ServerConfig{ContainerLogDir: "/tmp/logs"}
+
+	assert.Equal(t, "pup-demo", config.PupLogFileName("demo"))
+	assert.Equal(t, filepath.Join("/tmp/logs", "pup-demo"), config.PupLogPath("demo"))
+	assert.Equal(t, "job-demo", config.JobLogFileName("demo"))
+	assert.Equal(t, filepath.Join("/tmp/logs", "job-demo"), config.JobLogPath("demo"))
+}

--- a/pkg/system/logtailer.go
+++ b/pkg/system/logtailer.go
@@ -8,10 +8,7 @@ import (
 	"io"
 	"log"
 	"os"
-	"path/filepath"
 	"time"
-
-	dogeboxd "github.com/Dogebox-WG/dogeboxd/pkg"
 )
 
 const maxInitialLines = 1000
@@ -19,28 +16,22 @@ const tailReadChunkSize int64 = 8192
 const logFileOpenAttempts = 300
 const logFileOpenRetryDelay = 100 * time.Millisecond
 
-func NewLogTailer(config dogeboxd.ServerConfig) LogTailer {
-	return LogTailer{
-		config: config,
-	}
+func NewLogTailer() LogTailer {
+	return LogTailer{}
 }
 
-type LogTailer struct {
-	config dogeboxd.ServerConfig
+type LogTailer struct{}
+
+func (t LogTailer) GetChannel(logFile string) (context.CancelFunc, chan string, error) {
+	return t.GetChannelFromOffset(logFile, -1)
 }
 
-func (t LogTailer) GetChannel(pupId string) (context.CancelFunc, chan string, error) {
-	return t.GetChannelFromOffset(pupId, -1)
-}
-
-func (t LogTailer) GetChannelFromOffset(pupId string, startOffset int64) (context.CancelFunc, chan string, error) {
+func (t LogTailer) GetChannelFromOffset(logFile string, startOffset int64) (context.CancelFunc, chan string, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	out := make(chan string, 10)
 
 	go func() {
-		logFile := filepath.Join(t.config.ContainerLogDir, "pup-"+pupId)
-
 		// Wait for the file to be created (up to 30 seconds)
 		file, err := waitForLogFile(logFile)
 		if err != nil {
@@ -90,12 +81,10 @@ func (t LogTailer) GetChannelFromOffset(pupId string, startOffset int64) (contex
 	return cancel, out, nil
 }
 
-func (t LogTailer) GetTail(pupId string, limit int) ([]string, int64, error) {
+func (t LogTailer) GetTail(logFile string, limit int) ([]string, int64, error) {
 	if limit <= 0 {
 		return nil, 0, fmt.Errorf("Log tail limit must be greater than zero")
 	}
-
-	logFile := filepath.Join(t.config.ContainerLogDir, "pup-"+pupId)
 
 	file, err := os.Open(logFile)
 	if err != nil {

--- a/pkg/web/logs.go
+++ b/pkg/web/logs.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strconv"
 )
 
@@ -35,7 +34,7 @@ func (t api) downloadPupLog(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	t.streamLogDownload(w, "pup-"+pupID, "pup-"+pupID+".log")
+	t.streamLogDownload(w, t.config.PupLogPath(pupID), t.config.PupLogFileName(pupID)+".log")
 }
 
 func (t api) downloadJobLog(w http.ResponseWriter, r *http.Request) {
@@ -50,7 +49,7 @@ func (t api) downloadJobLog(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	t.streamLogDownload(w, "pup-"+jobID, "job-"+jobID+".log")
+	t.streamLogDownload(w, t.config.JobLogPath(jobID), t.config.JobLogFileName(jobID)+".log")
 }
 
 func (t api) getPupLogTail(w http.ResponseWriter, r *http.Request) {
@@ -103,8 +102,7 @@ func parseLogTailLimit(r *http.Request) (int, error) {
 	return limit, nil
 }
 
-func (t api) streamLogDownload(w http.ResponseWriter, logFileName string, downloadName string) {
-	logPath := filepath.Join(t.config.ContainerLogDir, logFileName)
+func (t api) streamLogDownload(w http.ResponseWriter, logPath string, downloadName string) {
 	logFile, err := os.Open(logPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -121,6 +119,6 @@ func (t api) streamLogDownload(w http.ResponseWriter, logFileName string, downlo
 	w.Header().Set("Cache-Control", "no-store")
 
 	if _, err := io.Copy(w, logFile); err != nil {
-		log.Printf("Error streaming log file %s: %v", logFileName, err)
+		log.Printf("Error streaming log file %s: %v", logPath, err)
 	}
 }


### PR DESCRIPTION
### Separate pup and job logs

This gives job logs and pup logs distinct file prefixes. It also simplifies the backend log plumbing

### New features

* Job activity logs are now written to `job-<id>` files instead of sharing the `pup-<id>` prefix.
* Log source resolution is centralised so journal-backed logs and file-backed logs follow a simpler backend flow.