### PR TITLE
Log Pagination - Backend

### DIFF
--- a/cmd/dogeboxd/server.go
+++ b/cmd/dogeboxd/server.go
@@ -71,7 +71,7 @@ func (t server) Start() {
 
 	systemUpdater := system.NewSystemUpdater(t.config, networkManager, nixManager, sourceManager, pups, t.sm, lifecycleManager, dkm)
 	journalReader := system.NewJournalReader(t.config)
-	logtailer := system.NewLogTailer(t.config)
+	logtailer := system.NewLogTailer()
 
 	/* ----------------------------------------------------------------------- */
 	// Set up PupManager and load the state for all installed pups

--- a/pkg/action_logger.go
+++ b/pkg/action_logger.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"os/exec"
-	"path/filepath"
 	"time"
 
 	"gopkg.in/natefinch/lumberjack.v2"
@@ -95,7 +94,7 @@ func (t *stepLogger) writeToLogFile(msg string) {
 	if t.l.dbx.config != nil {
 		logDir := t.l.dbx.config.ContainerLogDir
 		if logDir != "" {
-			logFile := filepath.Join(logDir, "pup-"+t.l.Job.ID)
+			logFile := t.l.dbx.config.JobLogPath(t.l.Job.ID)
 
 			// Use lumberjack for log rotation
 			writer := &lumberjack.Logger{

--- a/pkg/action_logger_test.go
+++ b/pkg/action_logger_test.go
@@ -2,7 +2,9 @@ package dogeboxd
 
 import (
 	"bytes"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -563,4 +565,24 @@ func TestActionLoggerProgressOver100(t *testing.T) {
 	step.Progress(150).Log("Message")
 
 	assert.Equal(t, 150, step.progress)
+}
+
+func TestActionLoggerWritesJobLogsToJobPrefixedFile(t *testing.T) {
+	tempDir := t.TempDir()
+	job := createTestJob("InstallPup")
+	testDBX := &Dogeboxd{
+		Changes: make(chan Change, 100),
+		config:  &ServerConfig{ContainerLogDir: tempDir},
+	}
+	logger := NewActionLogger(job, "test-pup-id", *testDBX)
+
+	logger.Step("test-step").Log("Test message")
+
+	jobLogPath := filepath.Join(tempDir, "job-"+job.ID)
+	logData, err := os.ReadFile(jobLogPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(logData), "Test message")
+
+	_, err = os.Stat(filepath.Join(tempDir, "pup-"+job.ID))
+	assert.ErrorIs(t, err, os.ErrNotExist)
 }

--- a/pkg/action_logger_test.go
+++ b/pkg/action_logger_test.go
@@ -235,6 +235,7 @@ func TestActionLoggerLineWriterCapturesOutput(t *testing.T) {
 	assert.Equal(t, "line3", captured[2])
 }
 
+
 func TestActionLoggerLineWriterBuffersPartialLines(t *testing.T) {
 	var captured []string
 	writer := NewLineWriter(func(s string) {

--- a/pkg/dogeboxd.go
+++ b/pkg/dogeboxd.go
@@ -910,21 +910,24 @@ func (t Dogeboxd) getLogChannel(source logSource, resumeToken *string) (context.
 	return t.logtailer.GetChannel(source.filePath)
 }
 
-func (t Dogeboxd) getLogTail(source logSource, limit int) ([]string, *string, error) {
+func (t Dogeboxd) getLogPage(source logSource, before *string, limit int) (LogPage, error) {
 	if limit <= 0 {
-		return nil, nil, fmt.Errorf("Log tail limit must be greater than zero")
+		return LogPage{}, fmt.Errorf("Log tail limit must be greater than zero")
 	}
 
 	if source.usesJournal() {
-		return t.JournalReader.GetJournalTail(source.journalService, limit)
+		return t.JournalReader.GetJournalPage(source.journalService, before, limit)
 	}
 
-	lines, resumeToken, err := t.logtailer.GetTail(source.filePath, limit)
-	if err != nil {
-		return nil, nil, err
+	if before != nil {
+		offset, err := parseLogOffsetResumeToken(*before)
+		if err != nil {
+			return LogPage{}, err
+		}
+		return t.logtailer.GetPage(source.filePath, &offset, limit)
 	}
 
-	return lines, logOffsetResumeToken(resumeToken), nil
+	return t.logtailer.GetPage(source.filePath, nil, limit)
 }
 
 func (t Dogeboxd) GetLogChannel(PupID string, resumeToken *string) (context.CancelFunc, chan string, error) {
@@ -937,12 +940,21 @@ func (t Dogeboxd) GetLogChannel(PupID string, resumeToken *string) (context.Canc
 }
 
 func (t Dogeboxd) GetLogTail(PupID string, limit int) ([]string, *string, error) {
-	source, err := t.resolvePupLogSource(PupID)
+	page, err := t.GetLogPage(PupID, nil, limit)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return t.getLogTail(source, limit)
+	return page.Lines, page.ResumeToken, nil
+}
+
+func (t Dogeboxd) GetLogPage(PupID string, before *string, limit int) (LogPage, error) {
+	source, err := t.resolvePupLogSource(PupID)
+	if err != nil {
+		return LogPage{}, err
+	}
+
+	return t.getLogPage(source, before, limit)
 }
 
 // GetJobLogChannel returns a log channel for a specific job
@@ -957,12 +969,21 @@ func (t Dogeboxd) GetJobLogChannel(JobID string, resumeToken *string) (context.C
 }
 
 func (t Dogeboxd) GetJobLogTail(JobID string, limit int) ([]string, *string, error) {
-	source, err := t.resolveJobLogSource(JobID)
+	page, err := t.GetJobLogPage(JobID, nil, limit)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return t.getLogTail(source, limit)
+	return page.Lines, page.ResumeToken, nil
+}
+
+func (t Dogeboxd) GetJobLogPage(JobID string, before *string, limit int) (LogPage, error) {
+	source, err := t.resolveJobLogSource(JobID)
+	if err != nil {
+		return LogPage{}, err
+	}
+
+	return t.getLogPage(source, before, limit)
 }
 
 func parseLogOffsetResumeToken(resumeToken string) (int64, error) {

--- a/pkg/dogeboxd.go
+++ b/pkg/dogeboxd.go
@@ -856,21 +856,47 @@ var allowedJournalServices = map[string]string{
 	"dkm": "dkm.service",
 }
 
-func (t Dogeboxd) GetLogChannel(PupID string, resumeToken *string) (context.CancelFunc, chan string, error) {
+type logSource struct {
+	journalService string
+	filePath       string
+}
+
+func (s logSource) usesJournal() bool {
+	return s.journalService != ""
+}
+
+func (t Dogeboxd) resolvePupLogSource(PupID string) (logSource, error) {
 	// We read dogeboxd and dkm from the host systemd journal,
 	// and read everything else (pups) from the container logs we export.
 	service, ok := allowedJournalServices[PupID]
 	if ok {
-		if resumeToken != nil {
-			return t.JournalReader.GetJournalChannelFromCursor(service, *resumeToken)
-		}
-		return t.JournalReader.GetJournalChannel(service)
+		return logSource{journalService: service}, nil
 	}
 
 	// Check that we've actually got a valid pup id.
 	_, _, err := t.Pups.GetPup(PupID)
 	if err != nil {
-		return nil, nil, err
+		return logSource{}, err
+	}
+
+	return logSource{filePath: t.config.PupLogPath(PupID)}, nil
+}
+
+func (t Dogeboxd) resolveJobLogSource(JobID string) (logSource, error) {
+	_, err := t.JobManager.GetJob(JobID)
+	if err != nil {
+		return logSource{}, fmt.Errorf("job not found: %s", JobID)
+	}
+
+	return logSource{filePath: t.config.JobLogPath(JobID)}, nil
+}
+
+func (t Dogeboxd) getLogChannel(source logSource, resumeToken *string) (context.CancelFunc, chan string, error) {
+	if source.usesJournal() {
+		if resumeToken != nil {
+			return t.JournalReader.GetJournalChannelFromCursor(source.journalService, *resumeToken)
+		}
+		return t.JournalReader.GetJournalChannel(source.journalService)
 	}
 
 	if resumeToken != nil {
@@ -878,72 +904,65 @@ func (t Dogeboxd) GetLogChannel(PupID string, resumeToken *string) (context.Canc
 		if err != nil {
 			return nil, nil, err
 		}
-		return t.logtailer.GetChannelFromOffset(PupID, offset)
+		return t.logtailer.GetChannelFromOffset(source.filePath, offset)
 	}
 
-	return t.logtailer.GetChannel(PupID)
+	return t.logtailer.GetChannel(source.filePath)
 }
 
-func (t Dogeboxd) GetLogTail(PupID string, limit int) ([]string, *string, error) {
+func (t Dogeboxd) getLogTail(source logSource, limit int) ([]string, *string, error) {
 	if limit <= 0 {
 		return nil, nil, fmt.Errorf("Log tail limit must be greater than zero")
 	}
 
-	service, ok := allowedJournalServices[PupID]
-	if ok {
-		lines, resumeToken, err := t.JournalReader.GetJournalTail(service, limit)
-		return lines, resumeToken, err
+	if source.usesJournal() {
+		return t.JournalReader.GetJournalTail(source.journalService, limit)
 	}
 
-	_, _, err := t.Pups.GetPup(PupID)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	lines, resumeToken, err := t.logtailer.GetTail(PupID, limit)
+	lines, resumeToken, err := t.logtailer.GetTail(source.filePath, limit)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	return lines, logOffsetResumeToken(resumeToken), nil
+}
+
+func (t Dogeboxd) GetLogChannel(PupID string, resumeToken *string) (context.CancelFunc, chan string, error) {
+	source, err := t.resolvePupLogSource(PupID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return t.getLogChannel(source, resumeToken)
+}
+
+func (t Dogeboxd) GetLogTail(PupID string, limit int) ([]string, *string, error) {
+	source, err := t.resolvePupLogSource(PupID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return t.getLogTail(source, limit)
 }
 
 // GetJobLogChannel returns a log channel for a specific job
 // Streams logs from the job's ActionLogger in real-time (same system as pup logs)
 func (t Dogeboxd) GetJobLogChannel(JobID string, resumeToken *string) (context.CancelFunc, chan string, error) {
-	// Verify job exists
-	_, err := t.JobManager.GetJob(JobID)
-	if err != nil {
-		return nil, nil, fmt.Errorf("job not found: %s", JobID)
-	}
-
-	if resumeToken != nil {
-		offset, err := parseLogOffsetResumeToken(*resumeToken)
-		if err != nil {
-			return nil, nil, err
-		}
-		return t.logtailer.GetChannelFromOffset(JobID, offset)
-	}
-
-	return t.logtailer.GetChannel(JobID)
-}
-
-func (t Dogeboxd) GetJobLogTail(JobID string, limit int) ([]string, *string, error) {
-	if limit <= 0 {
-		return nil, nil, fmt.Errorf("Log tail limit must be greater than zero")
-	}
-
-	_, err := t.JobManager.GetJob(JobID)
-	if err != nil {
-		return nil, nil, fmt.Errorf("job not found: %s", JobID)
-	}
-
-	lines, resumeToken, err := t.logtailer.GetTail(JobID, limit)
+	source, err := t.resolveJobLogSource(JobID)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return lines, logOffsetResumeToken(resumeToken), nil
+	return t.getLogChannel(source, resumeToken)
+}
+
+func (t Dogeboxd) GetJobLogTail(JobID string, limit int) ([]string, *string, error) {
+	source, err := t.resolveJobLogSource(JobID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return t.getLogTail(source, limit)
 }
 
 func parseLogOffsetResumeToken(resumeToken string) (int64, error) {

--- a/pkg/log_paths.go
+++ b/pkg/log_paths.go
@@ -1,0 +1,26 @@
+package dogeboxd
+
+import (
+	"path/filepath"
+)
+
+const (
+	pupLogPrefix = "pup-"
+	jobLogPrefix = "job-"
+)
+
+func (c ServerConfig) PupLogFileName(pupID string) string {
+	return pupLogPrefix + pupID
+}
+
+func (c ServerConfig) PupLogPath(pupID string) string {
+	return filepath.Join(c.ContainerLogDir, c.PupLogFileName(pupID))
+}
+
+func (c ServerConfig) JobLogFileName(jobID string) string {
+	return jobLogPrefix + jobID
+}
+
+func (c ServerConfig) JobLogPath(jobID string) string {
+	return filepath.Join(c.ContainerLogDir, c.JobLogFileName(jobID))
+}

--- a/pkg/log_paths_test.go
+++ b/pkg/log_paths_test.go
@@ -1,0 +1,178 @@
+package dogeboxd
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubLogTailer struct {
+	lastChannelPath   string
+	lastChannelOffset int64
+	lastTailPath      string
+	lastTailLimit     int
+}
+
+func (t *stubLogTailer) GetChannel(path string) (context.CancelFunc, chan string, error) {
+	t.lastChannelPath = path
+	return func() {}, make(chan string), nil
+}
+
+func (t *stubLogTailer) GetChannelFromOffset(path string, offset int64) (context.CancelFunc, chan string, error) {
+	t.lastChannelPath = path
+	t.lastChannelOffset = offset
+	return func() {}, make(chan string), nil
+}
+
+func (t *stubLogTailer) GetTail(path string, limit int) ([]string, int64, error) {
+	t.lastTailPath = path
+	t.lastTailLimit = limit
+	return []string{filepath.Base(path)}, 42, nil
+}
+
+type stubJournalReader struct {
+	lastChannelService string
+	lastChannelCursor  string
+	lastTailService    string
+	lastTailLimit      int
+}
+
+func (t *stubJournalReader) GetJournalChannel(service string) (context.CancelFunc, chan string, error) {
+	t.lastChannelService = service
+	return func() {}, make(chan string), nil
+}
+
+func (t *stubJournalReader) GetJournalChannelFromCursor(service string, cursor string) (context.CancelFunc, chan string, error) {
+	t.lastChannelService = service
+	t.lastChannelCursor = cursor
+	return func() {}, make(chan string), nil
+}
+
+func (t *stubJournalReader) GetJournalTail(service string, limit int) ([]string, *string, error) {
+	t.lastTailService = service
+	t.lastTailLimit = limit
+	resumeToken := "journal-cursor"
+	return []string{service}, &resumeToken, nil
+}
+
+func TestDogeboxdGetJobLogTailUsesJobPath(t *testing.T) {
+	config := &ServerConfig{ContainerLogDir: t.TempDir()}
+
+	jm, err := setupTestJobManager()
+	require.NoError(t, err)
+
+	logtailer := &stubLogTailer{}
+	dbx := Dogeboxd{
+		JobManager: jm,
+		config:     config,
+		logtailer:  logtailer,
+	}
+
+	job := createTestJob("InstallPup")
+	_, err = jm.CreateJobRecord(job)
+	require.NoError(t, err)
+
+	lines, resumeToken, err := dbx.GetJobLogTail(job.ID, 10)
+	require.NoError(t, err)
+	require.NotNil(t, resumeToken)
+	assert.Equal(t, []string{filepath.Base(config.JobLogPath(job.ID))}, lines)
+	assert.Equal(t, config.JobLogPath(job.ID), logtailer.lastTailPath)
+	assert.Equal(t, 10, logtailer.lastTailLimit)
+}
+
+func TestDogeboxdGetJobLogChannelUsesJobPath(t *testing.T) {
+	config := &ServerConfig{ContainerLogDir: t.TempDir()}
+
+	jm, err := setupTestJobManager()
+	require.NoError(t, err)
+
+	logtailer := &stubLogTailer{}
+	dbx := Dogeboxd{
+		JobManager: jm,
+		config:     config,
+		logtailer:  logtailer,
+	}
+
+	job := createTestJob("InstallPup")
+	_, err = jm.CreateJobRecord(job)
+	require.NoError(t, err)
+
+	t.Run("without resume token", func(t *testing.T) {
+		cancel, channel, err := dbx.GetJobLogChannel(job.ID, nil)
+		require.NoError(t, err)
+		require.NotNil(t, cancel)
+		require.NotNil(t, channel)
+		assert.Equal(t, config.JobLogPath(job.ID), logtailer.lastChannelPath)
+		assert.Equal(t, int64(0), logtailer.lastChannelOffset)
+	})
+
+	t.Run("with resume token", func(t *testing.T) {
+		resumeToken := "123"
+		cancel, channel, err := dbx.GetJobLogChannel(job.ID, &resumeToken)
+		require.NoError(t, err)
+		require.NotNil(t, cancel)
+		require.NotNil(t, channel)
+		assert.Equal(t, config.JobLogPath(job.ID), logtailer.lastChannelPath)
+		assert.Equal(t, int64(123), logtailer.lastChannelOffset)
+	})
+}
+
+func TestDogeboxdGetLogChannelUsesJournalSource(t *testing.T) {
+	journalReader := &stubJournalReader{}
+	logtailer := &stubLogTailer{}
+	dbx := Dogeboxd{
+		JournalReader: journalReader,
+		logtailer:     logtailer,
+		config:        &ServerConfig{ContainerLogDir: t.TempDir()},
+	}
+
+	t.Run("without resume token", func(t *testing.T) {
+		cancel, channel, err := dbx.GetLogChannel("dbx", nil)
+		require.NoError(t, err)
+		require.NotNil(t, cancel)
+		require.NotNil(t, channel)
+		assert.Equal(t, "dogeboxd.service", journalReader.lastChannelService)
+		assert.Equal(t, "", logtailer.lastChannelPath)
+	})
+
+	t.Run("with resume token", func(t *testing.T) {
+		resumeToken := "cursor-123"
+		cancel, channel, err := dbx.GetLogChannel("dkm", &resumeToken)
+		require.NoError(t, err)
+		require.NotNil(t, cancel)
+		require.NotNil(t, channel)
+		assert.Equal(t, "dkm.service", journalReader.lastChannelService)
+		assert.Equal(t, "cursor-123", journalReader.lastChannelCursor)
+		assert.Equal(t, "", logtailer.lastChannelPath)
+	})
+}
+
+func TestDogeboxdGetLogTailUsesJournalSource(t *testing.T) {
+	journalReader := &stubJournalReader{}
+	logtailer := &stubLogTailer{}
+	dbx := Dogeboxd{
+		JournalReader: journalReader,
+		logtailer:     logtailer,
+		config:        &ServerConfig{ContainerLogDir: t.TempDir()},
+	}
+
+	lines, resumeToken, err := dbx.GetLogTail("dbx", 25)
+	require.NoError(t, err)
+	require.NotNil(t, resumeToken)
+	assert.Equal(t, []string{"dogeboxd.service"}, lines)
+	assert.Equal(t, "dogeboxd.service", journalReader.lastTailService)
+	assert.Equal(t, 25, journalReader.lastTailLimit)
+	assert.Equal(t, "", logtailer.lastTailPath)
+}
+
+func TestServerConfigLogFileNames(t *testing.T) {
+	config := ServerConfig{ContainerLogDir: "/tmp/logs"}
+
+	assert.Equal(t, "pup-demo", config.PupLogFileName("demo"))
+	assert.Equal(t, filepath.Join("/tmp/logs", "pup-demo"), config.PupLogPath("demo"))
+	assert.Equal(t, "job-demo", config.JobLogFileName("demo"))
+	assert.Equal(t, filepath.Join("/tmp/logs", "job-demo"), config.JobLogPath("demo"))
+}

--- a/pkg/log_paths_test.go
+++ b/pkg/log_paths_test.go
@@ -14,6 +14,9 @@ type stubLogTailer struct {
 	lastChannelOffset int64
 	lastTailPath      string
 	lastTailLimit     int
+	lastPagePath      string
+	lastPageLimit     int
+	lastPageBefore    *int64
 }
 
 func (t *stubLogTailer) GetChannel(path string) (context.CancelFunc, chan string, error) {
@@ -33,11 +36,26 @@ func (t *stubLogTailer) GetTail(path string, limit int) ([]string, int64, error)
 	return []string{filepath.Base(path)}, 42, nil
 }
 
+func (t *stubLogTailer) GetPage(path string, before *int64, limit int) (LogPage, error) {
+	t.lastPagePath = path
+	t.lastPageBefore = before
+	t.lastPageLimit = limit
+
+	resumeToken := "42"
+	return LogPage{
+		Lines:       []string{filepath.Base(path)},
+		ResumeToken: &resumeToken,
+	}, nil
+}
+
 type stubJournalReader struct {
 	lastChannelService string
 	lastChannelCursor  string
 	lastTailService    string
 	lastTailLimit      int
+	lastPageService    string
+	lastPageBefore     *string
+	lastPageLimit      int
 }
 
 func (t *stubJournalReader) GetJournalChannel(service string) (context.CancelFunc, chan string, error) {
@@ -56,6 +74,18 @@ func (t *stubJournalReader) GetJournalTail(service string, limit int) ([]string,
 	t.lastTailLimit = limit
 	resumeToken := "journal-cursor"
 	return []string{service}, &resumeToken, nil
+}
+
+func (t *stubJournalReader) GetJournalPage(service string, before *string, limit int) (LogPage, error) {
+	t.lastPageService = service
+	t.lastPageBefore = before
+	t.lastPageLimit = limit
+
+	resumeToken := "journal-cursor"
+	return LogPage{
+		Lines:       []string{service},
+		ResumeToken: &resumeToken,
+	}, nil
 }
 
 func TestDogeboxdGetJobLogTailUsesJobPath(t *testing.T) {
@@ -79,8 +109,9 @@ func TestDogeboxdGetJobLogTailUsesJobPath(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resumeToken)
 	assert.Equal(t, []string{filepath.Base(config.JobLogPath(job.ID))}, lines)
-	assert.Equal(t, config.JobLogPath(job.ID), logtailer.lastTailPath)
-	assert.Equal(t, 10, logtailer.lastTailLimit)
+	assert.Equal(t, config.JobLogPath(job.ID), logtailer.lastPagePath)
+	assert.Equal(t, 10, logtailer.lastPageLimit)
+	assert.Nil(t, logtailer.lastPageBefore)
 }
 
 func TestDogeboxdGetJobLogChannelUsesJobPath(t *testing.T) {
@@ -163,8 +194,9 @@ func TestDogeboxdGetLogTailUsesJournalSource(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resumeToken)
 	assert.Equal(t, []string{"dogeboxd.service"}, lines)
-	assert.Equal(t, "dogeboxd.service", journalReader.lastTailService)
-	assert.Equal(t, 25, journalReader.lastTailLimit)
+	assert.Equal(t, "dogeboxd.service", journalReader.lastPageService)
+	assert.Equal(t, 25, journalReader.lastPageLimit)
+	assert.Nil(t, journalReader.lastPageBefore)
 	assert.Equal(t, "", logtailer.lastTailPath)
 }
 

--- a/pkg/sys.go
+++ b/pkg/sys.go
@@ -39,16 +39,25 @@ type SystemMonitor interface {
 // actively listen for systemd journal entries
 // for a given systemd service, close channel
 // when done
+type LogPage struct {
+	Lines        []string `json:"lines"`
+	ResumeToken  *string  `json:"resumeToken,omitempty"`
+	OlderCursor  *string  `json:"olderCursor,omitempty"`
+	HasMoreOlder bool     `json:"hasMoreOlder"`
+}
+
 type JournalReader interface {
 	GetJournalChannel(string) (context.CancelFunc, chan string, error)
 	GetJournalChannelFromCursor(string, string) (context.CancelFunc, chan string, error)
 	GetJournalTail(string, int) ([]string, *string, error)
+	GetJournalPage(string, *string, int) (LogPage, error)
 }
 
 type LogTailer interface {
 	GetChannel(string) (context.CancelFunc, chan string, error)
 	GetChannelFromOffset(string, int64) (context.CancelFunc, chan string, error)
 	GetTail(string, int) ([]string, int64, error)
+	GetPage(string, *int64, int) (LogPage, error)
 }
 
 // SystemMonitor issues these for monitored PUPs

--- a/pkg/system/journal.go
+++ b/pkg/system/journal.go
@@ -9,6 +9,11 @@ import (
 	"github.com/coreos/go-systemd/sdjournal"
 )
 
+type journalEntry struct {
+	message string
+	cursor  string
+}
+
 func NewJournalReader(config dogeboxd.ServerConfig) JournalReader {
 	return JournalReader{
 		config: config,
@@ -104,37 +109,75 @@ func (t JournalReader) getJournalChannel(service string, cursor *string) (contex
 }
 
 func (t JournalReader) GetJournalTail(service string, limit int) ([]string, *string, error) {
+	page, err := t.GetJournalPage(service, nil, limit)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return page.Lines, page.ResumeToken, nil
+}
+
+func (t JournalReader) GetJournalPage(service string, before *string, limit int) (dogeboxd.LogPage, error) {
 	if limit <= 0 {
-		return nil, nil, fmt.Errorf("Log tail limit must be greater than zero")
+		return dogeboxd.LogPage{}, fmt.Errorf("Log tail limit must be greater than zero")
 	}
 
 	j, err := sdjournal.NewJournal()
 	if err != nil {
-		return nil, nil, err
+		return dogeboxd.LogPage{}, err
 	}
 	defer j.Close()
 
 	err = j.AddMatch(fmt.Sprintf("_SYSTEMD_UNIT=%s", service))
 	if err != nil {
-		return nil, nil, err
+		return dogeboxd.LogPage{}, err
 	}
 
-	err = j.SeekTail()
+	if before != nil {
+		err = j.SeekCursor(*before)
+	} else {
+		err = j.SeekTail()
+	}
 	if err != nil {
-		return nil, nil, err
+		return dogeboxd.LogPage{}, err
 	}
 
-	_, err = j.PreviousSkip(uint64(limit))
+	entries, hasMoreOlder, err := collectJournalEntriesBackward(j, limit)
 	if err != nil {
-		return nil, nil, err
+		return dogeboxd.LogPage{}, err
 	}
 
-	lines := []string{}
-	var lastCursor *string
-	for {
-		n, err := j.Next()
+	page := dogeboxd.LogPage{
+		Lines:        make([]string, len(entries)),
+		HasMoreOlder: hasMoreOlder,
+	}
+	for i, entry := range entries {
+		page.Lines[i] = entry.message
+	}
+	if len(entries) > 0 {
+		resumeToken := entries[len(entries)-1].cursor
+		page.ResumeToken = &resumeToken
+	}
+	if hasMoreOlder && len(entries) > 0 {
+		olderCursor := entries[0].cursor
+		page.OlderCursor = &olderCursor
+	}
+
+	return page, nil
+}
+
+type journalNavigator interface {
+	Previous() (uint64, error)
+	GetEntry() (*sdjournal.JournalEntry, error)
+	GetCursor() (string, error)
+}
+
+func collectJournalEntriesBackward(j journalNavigator, limit int) ([]journalEntry, bool, error) {
+	entriesNewestFirst := make([]journalEntry, 0, limit+1)
+	for len(entriesNewestFirst) < limit+1 {
+		n, err := j.Previous()
 		if err != nil {
-			return nil, nil, err
+			return nil, false, err
 		}
 		if n == 0 {
 			break
@@ -142,17 +185,29 @@ func (t JournalReader) GetJournalTail(service string, limit int) ([]string, *str
 
 		entry, err := j.GetEntry()
 		if err != nil {
-			return nil, nil, err
+			return nil, false, err
 		}
 
 		cursor, err := j.GetCursor()
 		if err != nil {
-			return nil, nil, err
+			return nil, false, err
 		}
 
-		lastCursor = &cursor
-		lines = append(lines, entry.Fields["MESSAGE"])
+		entriesNewestFirst = append(entriesNewestFirst, journalEntry{
+			message: entry.Fields["MESSAGE"],
+			cursor:  cursor,
+		})
 	}
 
-	return lines, lastCursor, nil
+	hasMoreOlder := len(entriesNewestFirst) > limit
+	if hasMoreOlder {
+		entriesNewestFirst = entriesNewestFirst[:limit]
+	}
+
+	entries := make([]journalEntry, len(entriesNewestFirst))
+	for i := range entriesNewestFirst {
+		entries[i] = entriesNewestFirst[len(entriesNewestFirst)-1-i]
+	}
+
+	return entries, hasMoreOlder, nil
 }

--- a/pkg/system/journal_test.go
+++ b/pkg/system/journal_test.go
@@ -1,0 +1,67 @@
+package system
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/coreos/go-systemd/sdjournal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeJournalNavigator struct {
+	entries []journalEntry
+	index   int
+	err     error
+}
+
+func (f *fakeJournalNavigator) Previous() (uint64, error) {
+	if f.err != nil {
+		return 0, f.err
+	}
+	if f.index >= len(f.entries) {
+		return 0, nil
+	}
+
+	f.index++
+	return 1, nil
+}
+
+func (f *fakeJournalNavigator) GetEntry() (*sdjournal.JournalEntry, error) {
+	entry := f.entries[f.index-1]
+	return &sdjournal.JournalEntry{
+		Fields: map[string]string{"MESSAGE": entry.message},
+	}, nil
+}
+
+func (f *fakeJournalNavigator) GetCursor() (string, error) {
+	return f.entries[f.index-1].cursor, nil
+}
+
+func TestCollectJournalEntriesBackwardReturnsChronologicalPage(t *testing.T) {
+	navigator := &fakeJournalNavigator{
+		entries: []journalEntry{
+			{message: "line-5", cursor: "cursor-5"},
+			{message: "line-4", cursor: "cursor-4"},
+			{message: "line-3", cursor: "cursor-3"},
+		},
+	}
+
+	entries, hasMoreOlder, err := collectJournalEntriesBackward(navigator, 2)
+	require.NoError(t, err)
+
+	assert.True(t, hasMoreOlder)
+	assert.Equal(t, []journalEntry{
+		{message: "line-4", cursor: "cursor-4"},
+		{message: "line-5", cursor: "cursor-5"},
+	}, entries)
+}
+
+func TestCollectJournalEntriesBackwardPropagatesErrors(t *testing.T) {
+	navigator := &fakeJournalNavigator{err: errors.New("boom")}
+
+	entries, hasMoreOlder, err := collectJournalEntriesBackward(navigator, 2)
+	require.Error(t, err)
+	assert.Nil(t, entries)
+	assert.False(t, hasMoreOlder)
+}

--- a/pkg/system/logtailer.go
+++ b/pkg/system/logtailer.go
@@ -8,7 +8,10 @@ import (
 	"io"
 	"log"
 	"os"
+	"strconv"
 	"time"
+
+	dogeboxd "github.com/Dogebox-WG/dogeboxd/pkg"
 )
 
 const maxInitialLines = 1000
@@ -82,25 +85,65 @@ func (t LogTailer) GetChannelFromOffset(logFile string, startOffset int64) (cont
 }
 
 func (t LogTailer) GetTail(logFile string, limit int) ([]string, int64, error) {
-	if limit <= 0 {
-		return nil, 0, fmt.Errorf("Log tail limit must be greater than zero")
+	page, err := t.GetPage(logFile, nil, limit)
+	if err != nil {
+		return nil, 0, err
 	}
 
+	if page.ResumeToken == nil {
+		return page.Lines, 0, nil
+	}
+
+	resumeToken, err := strconv.ParseInt(*page.ResumeToken, 10, 64)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return page.Lines, resumeToken, nil
+}
+
+func (t LogTailer) GetPage(logFile string, beforeOffset *int64, limit int) (dogeboxd.LogPage, error) {
+	if limit <= 0 {
+		return dogeboxd.LogPage{}, fmt.Errorf("Log tail limit must be greater than zero")
+	}
 	file, err := os.Open(logFile)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return []string{}, 0, nil
+			return dogeboxd.LogPage{Lines: []string{}}, nil
 		}
-		return nil, 0, err
+		return dogeboxd.LogPage{}, err
 	}
 	defer file.Close()
 
-	lines, cursor, err := readLastLines(file, limit)
+	stat, err := file.Stat()
 	if err != nil {
-		return nil, 0, err
+		return dogeboxd.LogPage{}, err
 	}
 
-	return lines, cursor, nil
+	endBefore := stat.Size()
+	if beforeOffset != nil {
+		endBefore = *beforeOffset
+	}
+
+	lines, oldestOffset, hasMoreOlder, err := readLastLinesBefore(file, endBefore, limit)
+	if err != nil {
+		return dogeboxd.LogPage{}, err
+	}
+
+	page := dogeboxd.LogPage{
+		Lines:        lines,
+		HasMoreOlder: hasMoreOlder,
+	}
+	if beforeOffset == nil {
+		resumeToken := strconv.FormatInt(stat.Size(), 10)
+		page.ResumeToken = &resumeToken
+	}
+	if hasMoreOlder {
+		olderCursor := strconv.FormatInt(oldestOffset, 10)
+		page.OlderCursor = &olderCursor
+	}
+
+	return page, nil
 }
 
 func waitForLogFile(logFile string) (*os.File, error) {
@@ -135,8 +178,9 @@ func resolveStartOffset(file *os.File, requestedOffset int64) (int64, error) {
 }
 
 func readLastLines(file *os.File, limit int) ([]string, int64, error) {
-	if limit <= 0 {
-		return nil, 0, fmt.Errorf("Log tail limit must be greater than zero")
+	lines, oldestOffset, _, err := readLastLinesBefore(file, -1, limit)
+	if err != nil {
+		return nil, 0, err
 	}
 
 	stat, err := file.Stat()
@@ -144,15 +188,38 @@ func readLastLines(file *os.File, limit int) ([]string, int64, error) {
 		return nil, 0, err
 	}
 
+	if oldestOffset == 0 && stat.Size() == 0 {
+		return lines, 0, nil
+	}
+
+	return lines, stat.Size(), nil
+}
+
+func readLastLinesBefore(file *os.File, endBefore int64, limit int) ([]string, int64, bool, error) {
+	if limit <= 0 {
+		return nil, 0, false, fmt.Errorf("Log tail limit must be greater than zero")
+	}
+
+	stat, err := file.Stat()
+	if err != nil {
+		return nil, 0, false, err
+	}
+
 	endOffset := stat.Size()
+	if endBefore >= 0 && endBefore < endOffset {
+		endOffset = endBefore
+	}
+	if endOffset < 0 {
+		endOffset = 0
+	}
 	if endOffset == 0 {
-		return []string{}, 0, nil
+		return []string{}, 0, false, nil
 	}
 
 	trailingByte := make([]byte, 1)
 	_, err = file.ReadAt(trailingByte, endOffset-1)
 	if err != nil && err != io.EOF {
-		return nil, 0, err
+		return nil, 0, false, err
 	}
 
 	newlinesNeeded := limit
@@ -172,7 +239,7 @@ func readLastLines(file *os.File, limit int) ([]string, int64, error) {
 		chunk := make([]byte, currentOffset-chunkStart)
 		_, err = file.ReadAt(chunk, chunkStart)
 		if err != nil && err != io.EOF {
-			return nil, 0, err
+			return nil, 0, false, err
 		}
 
 		for idx := len(chunk) - 1; idx >= 0; idx-- {
@@ -194,7 +261,7 @@ func readLastLines(file *os.File, limit int) ([]string, int64, error) {
 	reader := io.NewSectionReader(file, startOffset, endOffset-startOffset)
 	data, err := io.ReadAll(reader)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, false, err
 	}
 
 	lines := splitLogLines(data)
@@ -202,7 +269,7 @@ func readLastLines(file *os.File, limit int) ([]string, int64, error) {
 		lines = lines[len(lines)-limit:]
 	}
 
-	return lines, endOffset, nil
+	return lines, startOffset, startOffset > 0, nil
 }
 
 func splitLogLines(data []byte) []string {

--- a/pkg/system/logtailer.go
+++ b/pkg/system/logtailer.go
@@ -8,10 +8,7 @@ import (
 	"io"
 	"log"
 	"os"
-	"path/filepath"
 	"time"
-
-	dogeboxd "github.com/Dogebox-WG/dogeboxd/pkg"
 )
 
 const maxInitialLines = 1000
@@ -19,28 +16,22 @@ const tailReadChunkSize int64 = 8192
 const logFileOpenAttempts = 300
 const logFileOpenRetryDelay = 100 * time.Millisecond
 
-func NewLogTailer(config dogeboxd.ServerConfig) LogTailer {
-	return LogTailer{
-		config: config,
-	}
+func NewLogTailer() LogTailer {
+	return LogTailer{}
 }
 
-type LogTailer struct {
-	config dogeboxd.ServerConfig
+type LogTailer struct{}
+
+func (t LogTailer) GetChannel(logFile string) (context.CancelFunc, chan string, error) {
+	return t.GetChannelFromOffset(logFile, -1)
 }
 
-func (t LogTailer) GetChannel(pupId string) (context.CancelFunc, chan string, error) {
-	return t.GetChannelFromOffset(pupId, -1)
-}
-
-func (t LogTailer) GetChannelFromOffset(pupId string, startOffset int64) (context.CancelFunc, chan string, error) {
+func (t LogTailer) GetChannelFromOffset(logFile string, startOffset int64) (context.CancelFunc, chan string, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	out := make(chan string, 10)
 
 	go func() {
-		logFile := filepath.Join(t.config.ContainerLogDir, "pup-"+pupId)
-
 		// Wait for the file to be created (up to 30 seconds)
 		file, err := waitForLogFile(logFile)
 		if err != nil {
@@ -90,12 +81,10 @@ func (t LogTailer) GetChannelFromOffset(pupId string, startOffset int64) (contex
 	return cancel, out, nil
 }
 
-func (t LogTailer) GetTail(pupId string, limit int) ([]string, int64, error) {
+func (t LogTailer) GetTail(logFile string, limit int) ([]string, int64, error) {
 	if limit <= 0 {
 		return nil, 0, fmt.Errorf("Log tail limit must be greater than zero")
 	}
-
-	logFile := filepath.Join(t.config.ContainerLogDir, "pup-"+pupId)
 
 	file, err := os.Open(logFile)
 	if err != nil {

--- a/pkg/system/logtailer_test.go
+++ b/pkg/system/logtailer_test.go
@@ -1,0 +1,83 @@
+package system
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogTailerGetPagePaginatesOlderLines(t *testing.T) {
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "pup-test-pup")
+
+	lines := make([]string, 2505)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("line-%d", i+1)
+	}
+
+	err := os.WriteFile(logPath, []byte(strings.Join(lines, "\n")+"\n"), 0o644)
+	require.NoError(t, err)
+
+	tailer := NewLogTailer()
+
+	firstPage, err := tailer.GetPage(logPath, nil, 1000)
+	require.NoError(t, err)
+	require.Len(t, firstPage.Lines, 1000)
+	require.NotNil(t, firstPage.ResumeToken)
+	require.NotNil(t, firstPage.OlderCursor)
+	assert.True(t, firstPage.HasMoreOlder)
+	assert.Equal(t, "line-1506", firstPage.Lines[0])
+	assert.Equal(t, "line-2505", firstPage.Lines[len(firstPage.Lines)-1])
+
+	secondPage, err := tailer.GetPage(logPath, parseOffset(t, firstPage.OlderCursor), 1000)
+	require.NoError(t, err)
+	require.Len(t, secondPage.Lines, 1000)
+	require.Nil(t, secondPage.ResumeToken)
+	require.NotNil(t, secondPage.OlderCursor)
+	assert.True(t, secondPage.HasMoreOlder)
+	assert.Equal(t, "line-506", secondPage.Lines[0])
+	assert.Equal(t, "line-1505", secondPage.Lines[len(secondPage.Lines)-1])
+
+	finalPage, err := tailer.GetPage(logPath, parseOffset(t, secondPage.OlderCursor), 1000)
+	require.NoError(t, err)
+	require.Len(t, finalPage.Lines, 505)
+	require.Nil(t, finalPage.ResumeToken)
+	require.Nil(t, finalPage.OlderCursor)
+	assert.False(t, finalPage.HasMoreOlder)
+	assert.Equal(t, "line-1", finalPage.Lines[0])
+	assert.Equal(t, "line-505", finalPage.Lines[len(finalPage.Lines)-1])
+}
+
+func TestLogTailerGetPageHandlesBeforeStartOfFile(t *testing.T) {
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "pup-test-pup")
+
+	err := os.WriteFile(logPath, []byte("line-1\nline-2\n"), 0o644)
+	require.NoError(t, err)
+
+	tailer := NewLogTailer()
+
+	beforeStart := int64(0)
+	page, err := tailer.GetPage(logPath, &beforeStart, 1000)
+	require.NoError(t, err)
+	assert.Empty(t, page.Lines)
+	assert.Nil(t, page.ResumeToken)
+	assert.Nil(t, page.OlderCursor)
+	assert.False(t, page.HasMoreOlder)
+}
+
+func parseOffset(t *testing.T, offset *string) *int64 {
+	t.Helper()
+	require.NotNil(t, offset)
+
+	parsed, err := strconv.ParseInt(*offset, 10, 64)
+	require.NoError(t, err)
+
+	return &parsed
+}

--- a/pkg/web/logs.go
+++ b/pkg/web/logs.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strconv"
 )
 
@@ -35,7 +34,7 @@ func (t api) downloadPupLog(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	t.streamLogDownload(w, "pup-"+pupID, "pup-"+pupID+".log")
+	t.streamLogDownload(w, t.config.PupLogPath(pupID), t.config.PupLogFileName(pupID)+".log")
 }
 
 func (t api) downloadJobLog(w http.ResponseWriter, r *http.Request) {
@@ -50,7 +49,7 @@ func (t api) downloadJobLog(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	t.streamLogDownload(w, "pup-"+jobID, "job-"+jobID+".log")
+	t.streamLogDownload(w, t.config.JobLogPath(jobID), t.config.JobLogFileName(jobID)+".log")
 }
 
 func (t api) getPupLogTail(w http.ResponseWriter, r *http.Request) {
@@ -103,8 +102,7 @@ func parseLogTailLimit(r *http.Request) (int, error) {
 	return limit, nil
 }
 
-func (t api) streamLogDownload(w http.ResponseWriter, logFileName string, downloadName string) {
-	logPath := filepath.Join(t.config.ContainerLogDir, logFileName)
+func (t api) streamLogDownload(w http.ResponseWriter, logPath string, downloadName string) {
 	logFile, err := os.Open(logPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -121,6 +119,6 @@ func (t api) streamLogDownload(w http.ResponseWriter, logFileName string, downlo
 	w.Header().Set("Cache-Control", "no-store")
 
 	if _, err := io.Copy(w, logFile); err != nil {
-		log.Printf("Error streaming log file %s: %v", logFileName, err)
+		log.Printf("Error streaming log file %s: %v", logPath, err)
 	}
 }

--- a/pkg/web/logs.go
+++ b/pkg/web/logs.go
@@ -8,13 +8,17 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+
+	dogeboxd "github.com/Dogebox-WG/dogeboxd/pkg"
 )
 
 const defaultLogTailLimit = 1000
 
 type logTailResponse struct {
-	Lines       []string `json:"lines"`
-	ResumeToken *string  `json:"resumeToken,omitempty"`
+	Lines        []string `json:"lines"`
+	ResumeToken  *string  `json:"resumeToken,omitempty"`
+	OlderCursor  *string  `json:"olderCursor,omitempty"`
+	HasMoreOlder bool     `json:"hasMoreOlder"`
 }
 
 func (t api) downloadPupLog(w http.ResponseWriter, r *http.Request) {
@@ -53,18 +57,18 @@ func (t api) downloadJobLog(w http.ResponseWriter, r *http.Request) {
 }
 
 func (t api) getPupLogTail(w http.ResponseWriter, r *http.Request) {
-	t.getLogTail(w, r, "PupID", t.dbx.GetLogTail)
+	t.getLogTail(w, r, "PupID", t.dbx.GetLogPage)
 }
 
 func (t api) getJobLogTail(w http.ResponseWriter, r *http.Request) {
-	t.getLogTail(w, r, "JobID", t.dbx.GetJobLogTail)
+	t.getLogTail(w, r, "JobID", t.dbx.GetJobLogPage)
 }
 
 func (t api) getLogTail(
 	w http.ResponseWriter,
 	r *http.Request,
 	pathValue string,
-	fetchTail func(string, int) ([]string, *string, error),
+	fetchTail func(string, *string, int) (dogeboxd.LogPage, error),
 ) {
 	logID := r.PathValue(pathValue)
 	limit, err := parseLogTailLimit(r)
@@ -73,13 +77,24 @@ func (t api) getLogTail(
 		return
 	}
 
-	lines, resumeToken, err := fetchTail(logID, limit)
+	before, err := parseLogTailBefore(r)
 	if err != nil {
 		sendErrorResponse(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
-	sendResponse(w, logTailResponse{Lines: lines, ResumeToken: resumeToken})
+	page, err := fetchTail(logID, before, limit)
+	if err != nil {
+		sendErrorResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	sendResponse(w, logTailResponse{
+		Lines:        page.Lines,
+		ResumeToken:  page.ResumeToken,
+		OlderCursor:  page.OlderCursor,
+		HasMoreOlder: page.HasMoreOlder,
+	})
 }
 
 func parseLogTailLimit(r *http.Request) (int, error) {
@@ -102,6 +117,14 @@ func parseLogTailLimit(r *http.Request) (int, error) {
 	return limit, nil
 }
 
+func parseLogTailBefore(r *http.Request) (*string, error) {
+	before := r.URL.Query().Get("before")
+	if before == "" {
+		return nil, nil
+	}
+
+	return &before, nil
+}
 func (t api) streamLogDownload(w http.ResponseWriter, logPath string, downloadName string) {
 	logFile, err := os.Open(logPath)
 	if err != nil {

--- a/pkg/web/logs_test.go
+++ b/pkg/web/logs_test.go
@@ -1,0 +1,66 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	dogeboxd "github.com/Dogebox-WG/dogeboxd/pkg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetLogTailReturnsPagingMetadata(t *testing.T) {
+	api := api{}
+
+	req := httptest.NewRequest(http.MethodGet, "/log/pup/test-pup/tail?limit=25&before=cursor-1", nil)
+	req.SetPathValue("PupID", "test-pup")
+	recorder := httptest.NewRecorder()
+
+	resumeToken := "resume-1"
+	olderCursor := "cursor-2"
+
+	api.getLogTail(recorder, req, "PupID", func(logID string, before *string, limit int) (dogeboxd.LogPage, error) {
+		require.Equal(t, "test-pup", logID)
+		require.NotNil(t, before)
+		require.Equal(t, "cursor-1", *before)
+		require.Equal(t, 25, limit)
+
+		return dogeboxd.LogPage{
+			Lines:        []string{"line-1", "line-2"},
+			ResumeToken:  &resumeToken,
+			OlderCursor:  &olderCursor,
+			HasMoreOlder: true,
+		}, nil
+	})
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+
+	var response logTailResponse
+	err := json.Unmarshal(recorder.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"line-1", "line-2"}, response.Lines)
+	require.NotNil(t, response.ResumeToken)
+	assert.Equal(t, "resume-1", *response.ResumeToken)
+	require.NotNil(t, response.OlderCursor)
+	assert.Equal(t, "cursor-2", *response.OlderCursor)
+	assert.True(t, response.HasMoreOlder)
+}
+
+func TestGetLogTailRejectsInvalidLimit(t *testing.T) {
+	api := api{}
+
+	req := httptest.NewRequest(http.MethodGet, "/log/pup/test-pup/tail?limit=0", nil)
+	req.SetPathValue("PupID", "test-pup")
+	recorder := httptest.NewRecorder()
+
+	api.getLogTail(recorder, req, "PupID", func(string, *string, int) (dogeboxd.LogPage, error) {
+		t.Fatal("fetch function should not be called for invalid limits")
+		return dogeboxd.LogPage{}, nil
+	})
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "Log tail limit must be greater than zero")
+}


### PR DESCRIPTION
### Make older logs available to the UI

This adds backward log pagination to the existing tail endpoints so the frontend can keep loading older output instead of stopping at the most recent 1000 lines.

### New features

* Log tail endpoints can return older pages of log lines using a cursor-based `before` query.
* Tail responses now include the metadata the frontend needs to continue paging backward safely.

**Frontend PR** - [Dogebox-WG/dpanel#247](https://github.com/Dogebox-WG/dpanel/pull/247)

**Required to be merged first** -  https://github.com/Dogebox-WG/dogeboxd/pull/220 
