### PR TITLE
Wired Network Name Simplification - Backend

### DIFF
--- a/pkg/sys.go
+++ b/pkg/sys.go
@@ -149,7 +149,6 @@ type NetworkConnection interface {
 type NetworkEthernet struct {
 	Type      string `json:"type"`
 	Interface string `json:"interface"`
-	Label     string `json:"label,omitempty"`
 	Active    bool   `json:"active"`
 }
 

--- a/pkg/system/network/linux.go
+++ b/pkg/system/network/linux.go
@@ -34,11 +34,6 @@ type WiFiNetwork struct {
 	Frequency string
 }
 
-var physicalInterfaceLabels = map[string]string{
-	"enP4p65s0": "ETH1",
-	"enP2p33s0": "ETH2",
-}
-
 func (t NetworkManagerLinux) GetAvailableNetworks() []dogeboxd.NetworkConnection {
 	availableNetworkConnections := []dogeboxd.NetworkConnection{}
 	wifiInterfaceNames := []string{}
@@ -121,7 +116,6 @@ outer:
 		availableNetworkConnections = append(availableNetworkConnections, dogeboxd.NetworkEthernet{
 			Type:      "ethernet",
 			Interface: systemInterface.Name,
-			Label:     physicalInterfaceLabels[systemInterface.Name],
 			Active:    interfaceHasCarrier(systemInterface.Name),
 		})
 	}


### PR DESCRIPTION
### Simpler wired network data from the backend

The backend now stops sending hard-coded ethernet labels and leaves wired network naming to the frontend while still reporting whether each interface is connected. This keeps the API simpler and avoids board-specific naming logic in `dogeboxd`.

### New features

* Removes hard-coded ethernet interface label mappings from the backend
* Keeps wired network responses focused on interface names and connected state
* Drops the obsolete ethernet `label` field from the backend response model

**Frontend PR** - [Dogebox-WG/dpanel#251](https://github.com/Dogebox-WG/dpanel/pull/251)
