### PR TITLE
Fix OS flake migration

### DIFF
--- a/cmd/_dbxroot/cmd/nix-rb.go
+++ b/cmd/_dbxroot/cmd/nix-rb.go
@@ -3,9 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"os/exec"
 
-	"github.com/Dogebox-WG/dogeboxd/cmd/_dbxroot/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -16,22 +14,7 @@ var rbCmd = &cobra.Command{
 	Use:   "rb",
 	Short: "Executes nixos-rebuild boot",
 	Run: func(cmd *cobra.Command, args []string) {
-		rebuildCommand, rebuildArgs, err := utils.GetRebuildCommand("boot", nixRBSetRelease, nixRBFlakeDir)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting rebuild command: %v\n", err)
-			os.Exit(1)
-		}
-
-		execCmd := exec.Command(rebuildCommand, rebuildArgs...)
-		execCmd.Stdout = os.Stdout
-		execCmd.Stderr = os.Stderr
-
-		if nixRBFlakeDir != "" {
-			execCmd.Env = append(os.Environ(), "DBX_UPGRADE_FLAKE_DIR="+nixRBFlakeDir)
-		}
-
-		err = execCmd.Run()
-		if err != nil {
+		if err := runNixOSRebuild("boot", nixRBSetRelease, nixRBFlakeDir); err != nil {
 			fmt.Fprintf(os.Stderr, "Error executing nixos-rebuild boot: %v\n", err)
 			os.Exit(1)
 		}

--- a/cmd/_dbxroot/cmd/nix-rb.go
+++ b/cmd/_dbxroot/cmd/nix-rb.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/Dogebox-WG/dogeboxd/cmd/_dbxroot/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -14,7 +15,7 @@ var rbCmd = &cobra.Command{
 	Use:   "rb",
 	Short: "Executes nixos-rebuild boot",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := runNixOSRebuild("boot", nixRBSetRelease, nixRBFlakeDir); err != nil {
+		if err := utils.RunNixOSRebuild("boot", nixRBSetRelease, nixRBFlakeDir); err != nil {
 			fmt.Fprintf(os.Stderr, "Error executing nixos-rebuild boot: %v\n", err)
 			os.Exit(1)
 		}

--- a/cmd/_dbxroot/cmd/nix-rebuild.go
+++ b/cmd/_dbxroot/cmd/nix-rebuild.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/Dogebox-WG/dogeboxd/cmd/_dbxroot/utils"
+)
+
+func runNixOSRebuild(action string, setRelease string, flakeDir string) error {
+	rebuildCommand, rebuildArgs, err := utils.GetRebuildCommand(action, setRelease, flakeDir)
+	if err != nil {
+		return err
+	}
+
+	execCmd := exec.Command(rebuildCommand, rebuildArgs...)
+	execCmd.Stdout = os.Stdout
+	execCmd.Stderr = os.Stderr
+
+	if flakeDir != "" {
+		execCmd.Env = append(os.Environ(), "DBX_UPGRADE_FLAKE_DIR="+flakeDir)
+	}
+
+	return execCmd.Run()
+}

--- a/cmd/_dbxroot/cmd/nix-rs.go
+++ b/cmd/_dbxroot/cmd/nix-rs.go
@@ -5,35 +5,89 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/Dogebox-WG/dogeboxd/cmd/_dbxroot/utils"
 	"github.com/spf13/cobra"
 )
 
 var nixRSSetRelease string
 var nixRSFlakeDir string
+var nixRSSystemdRun bool
+var nixRSSystemdUnit string
+var nixRSCleanupFlakeDir bool
+
+func runCurrentSystemActivation() error {
+	execCmd := exec.Command("/nix/var/nix/profiles/system/bin/switch-to-configuration", "switch")
+	execCmd.Stdout = os.Stdout
+	execCmd.Stderr = os.Stderr
+	return execCmd.Run()
+}
+
+func runSystemdWrappedRS() error {
+	unitName := nixRSSystemdUnit
+	if unitName == "" {
+		unitName = "dogebox-system-update"
+	}
+
+	fmt.Fprintf(os.Stderr, "Running nixos-rebuild switch in transient unit %s; follow detailed logs with journalctl -u %s\n", unitName, unitName)
+
+	execCmd := exec.Command("/run/current-system/sw/bin/systemd-run", buildSystemdRunRSArgs(unitName, nixRSFlakeDir, nixRSSetRelease, nixRSCleanupFlakeDir)...)
+	execCmd.Stdout = os.Stdout
+	execCmd.Stderr = os.Stderr
+	return execCmd.Run()
+}
+
+func buildSystemdRunRSArgs(unitName string, flakeDir string, setRelease string, cleanupFlakeDir bool) []string {
+	systemdArgs := []string{
+		"--unit", unitName,
+		"--collect",
+		"--wait",
+		// Do not use --pipe here: dogeboxd may be stopped during activation,
+		// but the transient unit must keep running to complete the switch.
+		"--setenv=PATH=/run/current-system/sw/bin:/run/wrappers/bin",
+		"/run/wrappers/bin/_dbxroot",
+		"nix",
+		"rs",
+	}
+	if flakeDir != "" {
+		systemdArgs = append(systemdArgs, "--flake-dir", flakeDir)
+	}
+	if cleanupFlakeDir {
+		systemdArgs = append(systemdArgs, "--cleanup-flake-dir")
+	}
+	if setRelease != "" {
+		systemdArgs = append(systemdArgs, "--set-release", setRelease)
+	}
+
+	return systemdArgs
+}
 
 var rsCmd = &cobra.Command{
 	Use:   "rs",
 	Short: "Executes nixos-rebuild switch",
 	Run: func(cmd *cobra.Command, args []string) {
-		rebuildCommand, rebuildArgs, err := utils.GetRebuildCommand("switch", nixRSSetRelease, nixRSFlakeDir)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting rebuild command: %v\n", err)
-			os.Exit(1)
+		if nixRSSystemdRun {
+			if err := runSystemdWrappedRS(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error executing nixos-rebuild switch in transient unit: %v\n", err)
+				os.Exit(1)
+			}
+			return
 		}
 
-		execCmd := exec.Command(rebuildCommand, rebuildArgs...)
-		execCmd.Stdout = os.Stdout
-		execCmd.Stderr = os.Stderr
-
-		if nixRSFlakeDir != "" {
-			execCmd.Env = append(os.Environ(), "DBX_UPGRADE_FLAKE_DIR="+nixRSFlakeDir)
-		}
-
-		err = execCmd.Run()
-		if err != nil {
+		if err := runNixOSRebuild("switch", nixRSSetRelease, nixRSFlakeDir); err != nil {
 			fmt.Fprintf(os.Stderr, "Error executing nixos-rebuild switch: %v\n", err)
 			os.Exit(1)
+		}
+
+		if nixRSFlakeDir != "" {
+			if err := runCurrentSystemActivation(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error activating rebuilt system profile: %v\n", err)
+				os.Exit(1)
+			}
+		}
+		if nixRSCleanupFlakeDir && nixRSFlakeDir != "" {
+			if err := os.RemoveAll(nixRSFlakeDir); err != nil {
+				fmt.Fprintf(os.Stderr, "Error cleaning staged flake directory %s: %v\n", nixRSFlakeDir, err)
+				os.Exit(1)
+			}
 		}
 	},
 }
@@ -41,5 +95,8 @@ var rsCmd = &cobra.Command{
 func init() {
 	rsCmd.Flags().StringVarP(&nixRSSetRelease, "set-release", "s", "", "rebuild with specific release (used for upgrades)")
 	rsCmd.Flags().StringVar(&nixRSFlakeDir, "flake-dir", "", "rebuild from a specific flake directory")
+	rsCmd.Flags().BoolVar(&nixRSSystemdRun, "systemd-run", false, "run rebuild inside a transient systemd unit")
+	rsCmd.Flags().StringVar(&nixRSSystemdUnit, "systemd-unit", "", "transient systemd unit name")
+	rsCmd.Flags().BoolVar(&nixRSCleanupFlakeDir, "cleanup-flake-dir", false, "remove the flake directory after a successful rebuild")
 	nixCmd.AddCommand(rsCmd)
 }

--- a/cmd/_dbxroot/cmd/nix-rs.go
+++ b/cmd/_dbxroot/cmd/nix-rs.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/Dogebox-WG/dogeboxd/cmd/_dbxroot/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -72,7 +73,7 @@ var rsCmd = &cobra.Command{
 			return
 		}
 
-		if err := runNixOSRebuild("switch", nixRSSetRelease, nixRSFlakeDir); err != nil {
+		if err := utils.RunNixOSRebuild("switch", nixRSSetRelease, nixRSFlakeDir); err != nil {
 			fmt.Fprintf(os.Stderr, "Error executing nixos-rebuild switch: %v\n", err)
 			os.Exit(1)
 		}

--- a/cmd/_dbxroot/utils/nix-rebuild.go
+++ b/cmd/_dbxroot/utils/nix-rebuild.go
@@ -1,14 +1,12 @@
-package cmd
+package utils
 
 import (
 	"os"
 	"os/exec"
-
-	"github.com/Dogebox-WG/dogeboxd/cmd/_dbxroot/utils"
 )
 
-func runNixOSRebuild(action string, setRelease string, flakeDir string) error {
-	rebuildCommand, rebuildArgs, err := utils.GetRebuildCommand(action, setRelease, flakeDir)
+func RunNixOSRebuild(action string, setRelease string, flakeDir string) error {
+	rebuildCommand, rebuildArgs, err := GetRebuildCommand(action, setRelease, flakeDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/dogeboxd/post_upgrade_migrations.go
+++ b/cmd/dogeboxd/post_upgrade_migrations.go
@@ -9,8 +9,9 @@ import (
 
 func (t server) checkAndPerformPostUpgradeMigrations(dbx dogeboxd.Dogeboxd) bool {
 	_, queued, err := migrations.RunPostUpgradeMigrations(migrations.Context{
-		Config:  t.config,
-		Enqueue: dbx.AddAction,
+		Config:     t.config,
+		Enqueue:    dbx.AddAction,
+		ActiveJobs: dbx.JobManager.GetActiveJobs,
 	})
 	if err != nil {
 		log.Printf("Post-upgrade migration runner failed: %v", err)

--- a/cmd/dogeboxd/server.go
+++ b/cmd/dogeboxd/server.go
@@ -102,6 +102,20 @@ func (t server) Start() {
 	dbx.SetJobManager(jobManager)
 	atomic.StoreUint32(&dbxReady, 1)
 
+	if reconciled, err := jobManager.ReconcileCompletedSystemUpdateJobs(); err == nil && reconciled > 0 {
+		log.Printf("Reconciled %d interrupted system update jobs to completed after restart", reconciled)
+	}
+
+	if cleared, err := jobManager.ClearInterruptedSystemJobs(); err == nil && cleared > 0 {
+		log.Printf("Cleaned up %d interrupted system jobs from previous run", cleared)
+	}
+
+	// Clean up any orphaned jobs from previous runs (stuck in queued/in_progress)
+	// before startup migrations inspect active work and decide whether to queue again.
+	if cleared, err := jobManager.ClearOrphanedJobs(30 * time.Minute); err == nil && cleared > 0 {
+		log.Printf("Cleaned up %d orphaned jobs from previous run", cleared)
+	}
+
 	if t.sm.Get().Dogebox.InitialState.HasFullyConfigured {
 		go func() {
 			if t.checkAndPerformPostUpgradeMigrations(dbx) {
@@ -111,12 +125,6 @@ func (t server) Start() {
 			jobID := dbx.AddAction(dogeboxd.UpdateNixCache{})
 			log.Printf("Queued startup nix cache update job: %s", jobID)
 		}()
-	}
-
-	// Clean up any orphaned jobs from previous runs (stuck in queued/in_progress)
-	// Jobs older than 30 minutes are considered orphaned on startup
-	if cleared, err := jobManager.ClearOrphanedJobs(30 * time.Minute); err == nil && cleared > 0 {
-		log.Printf("Cleaned up %d orphaned jobs from previous run", cleared)
 	}
 
 	//No need to show welcome screen if any pups are already installed (may have just done a system update or something similar)

--- a/pkg/jobs.go
+++ b/pkg/jobs.go
@@ -3,9 +3,16 @@ package dogeboxd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
+	"regexp"
+	"strings"
 	"sync"
 	"time"
+
+	"github.com/Dogebox-WG/dogeboxd/pkg/version"
+	"golang.org/x/mod/semver"
 )
 
 // JobStatus represents the current state of a job
@@ -25,12 +32,20 @@ type JobRecord struct {
 	Started        time.Time  `json:"started"`
 	Finished       *time.Time `json:"finished"` // nil if not finished
 	DisplayName    string     `json:"displayName"`
-	Action         string     `json:"action"`   // Action type: install, upgrade, uninstall, etc.
+	Action         string     `json:"action"` // Action type: install, upgrade, uninstall, etc.
+	TargetVersion  string     `json:"targetVersion,omitempty"`
 	Progress       int        `json:"progress"` // 0-100
 	Status         JobStatus  `json:"status"`
 	SummaryMessage string     `json:"summaryMessage"`
 	ErrorMessage   string     `json:"errorMessage"`
 	PupID          string     `json:"pupID"` // Associated pup if applicable
+}
+
+var reconciledInstalledOSFlakePath = "/etc/nixos/flake.nix"
+var reconciledOSFlakeVersionPattern = regexp.MustCompile(`(?m)^\s*dbxRelease\s*=\s*"(v[^"]+)"`)
+var reconciledReadFile = os.ReadFile
+var reconciledCurrentDBXRelease = func() string {
+	return version.GetDBXRelease().Release
 }
 
 // JobManager handles job persistence and state management
@@ -76,6 +91,9 @@ func (jm *JobManager) CreateJobRecord(j Job) (*JobRecord, error) {
 		SummaryMessage: "Job queued",
 		ErrorMessage:   "",
 		PupID:          pupID,
+	}
+	if action, ok := j.A.(SystemUpdate); ok {
+		record.TargetVersion = action.Version
 	}
 
 	if j.State != nil {
@@ -310,10 +328,205 @@ func (jm *JobManager) ClearOrphanedJobs(olderThan time.Duration) (int, error) {
 	return count, nil
 }
 
+// ReconcileCompletedSystemUpdateJobs marks interrupted system update jobs as
+// completed when the current runtime state already matches their target version.
+func (jm *JobManager) ReconcileCompletedSystemUpdateJobs() (int, error) {
+	currentDBXRelease := strings.TrimSpace(reconciledCurrentDBXRelease())
+	installedFlakeVersion, err := getReconciledInstalledOSFlakeVersion()
+	if err != nil {
+		return 0, err
+	}
+
+	activeJobs, err := jm.GetActiveJobs()
+	if err != nil {
+		return 0, err
+	}
+
+	reconciled := 0
+	for _, job := range activeJobs {
+		if !isInterruptedSystemJob(&job) {
+			continue
+		}
+
+		targetVersion := strings.TrimSpace(jm.resolveSystemUpdateTargetVersion(job))
+		if targetVersion == "" {
+			continue
+		}
+		if currentDBXRelease != targetVersion || installedFlakeVersion != targetVersion {
+			continue
+		}
+
+		if err := jm.CompleteJob(job.ID, ""); err != nil {
+			return reconciled, err
+		}
+		jm.appendJobRecoveryLog(job.ID, fmt.Sprintf("System update to %s completed after dogeboxd restart", targetVersion))
+		reconciled++
+	}
+
+	return reconciled, nil
+}
+
+// ClearInterruptedSystemJobs marks system-level jobs from a previous dogeboxd
+// process as failed. These jobs cannot resume after dogeboxd restarts, and if
+// they remain active they keep the updates UI locked.
+func (jm *JobManager) ClearInterruptedSystemJobs() (int, error) {
+	jm.jobsMutex.Lock()
+	defer jm.jobsMutex.Unlock()
+
+	now := time.Now()
+	count := 0
+	activeJobs, err := jm.getActiveSystemJobsLocked()
+	if err != nil {
+		return 0, err
+	}
+	for _, job := range activeJobs {
+		if err := jm.markInterruptedSystemJobAsFailedLocked(job, now); err != nil {
+			return count, err
+		}
+		count++
+	}
+
+	for id, job := range jm.activeJobs {
+		if job.Status != JobStatusQueued && job.Status != JobStatusInProgress {
+			continue
+		}
+		if isInterruptedSystemJob(job) {
+			delete(jm.activeJobs, id)
+		}
+	}
+
+	return count, nil
+}
+
 func (jm *JobManager) markOrphanedJobsAsFailed(finished time.Time, startedBefore time.Time) (int, error) {
 	query := fmt.Sprintf(`UPDATE %s SET value = json_set(json_set(json_set(value, '$.status', 'failed'), '$.errorMessage', 'Job was orphaned (stuck in queue)'), '$.finished', ?) WHERE json_extract(value, '$.status') IN ('queued', 'in_progress') AND json_extract(value, '$.started') < ?`, jm.store.Table)
 	count, err := jm.store.ExecWrite(query, finished.Format(time.RFC3339Nano), startedBefore.Format(time.RFC3339Nano))
 	return int(count), err
+}
+
+func (jm *JobManager) getActiveSystemJobsLocked() ([]JobRecord, error) {
+	activeJobs, err := jm.GetActiveJobs()
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := make([]JobRecord, 0, len(activeJobs))
+	for _, job := range activeJobs {
+		if isInterruptedSystemJob(&job) {
+			filtered = append(filtered, job)
+		}
+	}
+
+	return filtered, nil
+}
+
+func (jm *JobManager) markInterruptedSystemJobAsFailedLocked(job JobRecord, finished time.Time) error {
+	targetVersion := strings.TrimSpace(jm.resolveSystemUpdateTargetVersion(job))
+	job.Status = JobStatusFailed
+	job.Finished = &finished
+	job.ErrorMessage = interruptedSystemJobMessage(job)
+	job.SummaryMessage = "Job failed"
+	if err := jm.store.Set(job.ID, job); err != nil {
+		return err
+	}
+
+	note := interruptedSystemJobLogNote(job, targetVersion)
+	if note != "" {
+		jm.appendJobRecoveryLog(job.ID, note)
+	}
+
+	return nil
+}
+
+func isInterruptedSystemJob(job *JobRecord) bool {
+	if job == nil {
+		return false
+	}
+	if job.Action == (SystemUpdate{}).ActionName() {
+		return true
+	}
+
+	displayName := strings.ToLower(job.DisplayName)
+	return displayName == "system update"
+}
+
+func interruptedSystemJobMessage(job JobRecord) string {
+	return "Job was interrupted by dogeboxd restart"
+}
+
+func interruptedSystemJobLogNote(job JobRecord, targetVersion string) string {
+	if isExpectedManualRestartMigrationUpdate(targetVersion) {
+		return "System update was interrupted by dogeboxd restart. This is expected when performing a 0.8.x to 0.9.x update; restart dogeboxd to continue phase 2."
+	}
+
+	return ""
+}
+
+func isExpectedManualRestartMigrationUpdate(targetVersion string) bool {
+	targetVersion = strings.TrimSpace(targetVersion)
+	if targetVersion == "" {
+		return false
+	}
+
+	return semver.IsValid(targetVersion) && semver.Compare(targetVersion, "v0.9.0-rc.1") >= 0
+}
+
+func (jm *JobManager) resolveSystemUpdateTargetVersion(job JobRecord) string {
+	targetVersion := strings.TrimSpace(job.TargetVersion)
+	if targetVersion != "" {
+		return targetVersion
+	}
+
+	return strings.TrimSpace(jm.readSystemUpdateTargetVersionFromLog(job.ID))
+}
+
+func getReconciledInstalledOSFlakeVersion() (string, error) {
+	contents, err := reconciledReadFile(reconciledInstalledOSFlakePath)
+	if err != nil {
+		return "", err
+	}
+
+	match := reconciledOSFlakeVersionPattern.FindStringSubmatch(string(contents))
+	if len(match) != 2 {
+		return "", fmt.Errorf("installed os flake version not found in %s", reconciledInstalledOSFlakePath)
+	}
+
+	return strings.TrimSpace(match[1]), nil
+}
+
+func (jm *JobManager) readSystemUpdateTargetVersionFromLog(jobID string) string {
+	if jm.dbx == nil || jm.dbx.config == nil || jm.dbx.config.ContainerLogDir == "" {
+		return ""
+	}
+
+	logPath := filepath.Join(jm.dbx.config.ContainerLogDir, "pup-"+jobID)
+	contents, err := os.ReadFile(logPath)
+	if err != nil {
+		return ""
+	}
+
+	matches := regexp.MustCompile(`Starting system update to (v[^\s]+)`).FindAllStringSubmatch(string(contents), -1)
+	if len(matches) == 0 {
+		return ""
+	}
+
+	return matches[len(matches)-1][1]
+}
+
+func (jm *JobManager) appendJobRecoveryLog(jobID string, msg string) {
+	if jm.dbx == nil || jm.dbx.config == nil || jm.dbx.config.ContainerLogDir == "" {
+		return
+	}
+
+	logPath := filepath.Join(jm.dbx.config.ContainerLogDir, "pup-"+jobID)
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	timestamp := time.Now().Format("2006-01-02 15:04:05")
+	_, _ = fmt.Fprintf(f, "[%s] %s\n", timestamp, msg)
 }
 
 // getDisplayName returns a human-readable name for the job

--- a/pkg/jobs_test.go
+++ b/pkg/jobs_test.go
@@ -1,6 +1,8 @@
 package dogeboxd
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -86,6 +88,21 @@ func TestJobCreationDisplayName(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "Install test-app", record.DisplayName)
+}
+
+func TestJobCreationStoresSystemUpdateTargetVersion(t *testing.T) {
+	jm, err := setupTestJobManager()
+	require.NoError(t, err)
+
+	job := Job{
+		ID:    "system-update-job",
+		Start: time.Now(),
+		A:     SystemUpdate{Package: "os", Version: "v0.9.0-rc.8"},
+	}
+	record, err := jm.CreateJobRecord(job)
+	require.NoError(t, err)
+
+	assert.Equal(t, "v0.9.0-rc.8", record.TargetVersion)
 }
 
 // ============================================================================
@@ -525,6 +542,122 @@ func TestClearAllJobsClearsActiveCache(t *testing.T) {
 	cacheLen := len(jm.activeJobs)
 	jm.jobsMutex.RUnlock()
 	assert.Equal(t, 0, cacheLen)
+}
+
+func TestClearInterruptedSystemJobsMarksActiveSystemJobsFailed(t *testing.T) {
+	jm, err := setupTestJobManager()
+	require.NoError(t, err)
+
+	systemJob := Job{
+		ID:    "system-update-job",
+		Start: time.Now(),
+		A:     SystemUpdate{Package: "os", Version: "v0.9.0-rc.8"},
+	}
+	_, err = jm.CreateJobRecord(systemJob)
+	require.NoError(t, err)
+
+	installJob := createTestJob("InstallPup")
+	_, err = jm.CreateJobRecord(installJob)
+	require.NoError(t, err)
+
+	count, err := jm.ClearInterruptedSystemJobs()
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	systemRecord, err := jm.GetJob(systemJob.ID)
+	require.NoError(t, err)
+	assert.Equal(t, JobStatusFailed, systemRecord.Status)
+	assert.Equal(t, "Job was interrupted by dogeboxd restart", systemRecord.ErrorMessage)
+	assert.NotNil(t, systemRecord.Finished)
+
+	installRecord, err := jm.GetJob(installJob.ID)
+	require.NoError(t, err)
+	assert.Equal(t, JobStatusQueued, installRecord.Status)
+}
+
+func TestClearInterruptedSystemJobsAppendsMigrationRestartNoteToLog(t *testing.T) {
+	jm, testDBX, err := setupTestJobManagerWithDBX()
+	require.NoError(t, err)
+
+	logDir := t.TempDir()
+	testDBX.dbx.config.ContainerLogDir = logDir
+
+	legacyRecord := JobRecord{
+		ID:             "system-update-job",
+		Started:        time.Now(),
+		DisplayName:    "System Update",
+		Action:         "update",
+		Progress:       5,
+		Status:         JobStatusInProgress,
+		SummaryMessage: "Still active from an older build",
+	}
+	require.NoError(t, jm.store.Set(legacyRecord.ID, legacyRecord))
+	jm.activeJobs[legacyRecord.ID] = &legacyRecord
+
+	logPath := filepath.Join(logDir, "pup-"+legacyRecord.ID)
+	require.NoError(t, os.WriteFile(logPath, []byte("[2026-05-20 11:18:37] Starting system update to v0.9.0-rc.8\n"), 0644))
+
+	count, err := jm.ClearInterruptedSystemJobs()
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	logContents, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(logContents), "System update was interrupted by dogeboxd restart. This is expected when performing a 0.8.x to 0.9.x update; restart dogeboxd to continue phase 2.")
+}
+
+func TestReconcileCompletedSystemUpdateJobsMarksMatchingTargetCompleted(t *testing.T) {
+	jm, testDBX, err := setupTestJobManagerWithDBX()
+	require.NoError(t, err)
+
+	logDir := t.TempDir()
+	testDBX.dbx.config.ContainerLogDir = logDir
+
+	prevReadFile := reconciledReadFile
+	prevCurrentDBXRelease := reconciledCurrentDBXRelease
+	prevInstalledOSFlakePath := reconciledInstalledOSFlakePath
+	t.Cleanup(func() {
+		reconciledReadFile = prevReadFile
+		reconciledCurrentDBXRelease = prevCurrentDBXRelease
+		reconciledInstalledOSFlakePath = prevInstalledOSFlakePath
+	})
+
+	reconciledInstalledOSFlakePath = "/test/etc/nixos/flake.nix"
+	reconciledReadFile = func(path string) ([]byte, error) {
+		if path == reconciledInstalledOSFlakePath {
+			return []byte("dbxRelease = \"v0.9.0-rc.8\";\n"), nil
+		}
+		return nil, os.ErrNotExist
+	}
+	reconciledCurrentDBXRelease = func() string {
+		return "v0.9.0-rc.8"
+	}
+
+	systemJob := Job{
+		ID:    "system-update-job",
+		Start: time.Now(),
+		A:     SystemUpdate{Package: "os", Version: "v0.9.0-rc.8"},
+	}
+	_, err = jm.CreateJobRecord(systemJob)
+	require.NoError(t, err)
+
+	logPath := filepath.Join(logDir, "pup-"+systemJob.ID)
+	require.NoError(t, os.WriteFile(logPath, []byte("[2026-05-20 10:52:21] Running as unit: dogebox-system-update-v0-9-0-rc-8.service\n"), 0644))
+
+	count, err := jm.ReconcileCompletedSystemUpdateJobs()
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	record, err := jm.GetJob(systemJob.ID)
+	require.NoError(t, err)
+	assert.Equal(t, JobStatusCompleted, record.Status)
+	assert.Equal(t, "Job completed successfully", record.SummaryMessage)
+	assert.NotNil(t, record.Finished)
+	assert.Equal(t, "", record.ErrorMessage)
+
+	logContents, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(logContents), "System update to v0.9.0-rc.8 completed after dogeboxd restart")
 }
 
 // ============================================================================

--- a/pkg/system/migrations/core/constraints_test.go
+++ b/pkg/system/migrations/core/constraints_test.go
@@ -64,10 +64,10 @@ func TestVersionConstraintCheck(t *testing.T) {
 			expected:   true,
 		},
 		{
-			name:       "greater than comparator excludes later patch in same minor line",
+			name:       "greater than comparator includes later patch in same minor line",
 			current:    "v0.9.1",
 			constraint: ">v0.9.0",
-			expected:   false,
+			expected:   true,
 		},
 	}
 

--- a/pkg/system/migrations/core/runner.go
+++ b/pkg/system/migrations/core/runner.go
@@ -11,6 +11,7 @@ import (
 type Context struct {
 	Config          dogeboxd.ServerConfig
 	Enqueue         func(dogeboxd.Action) string
+	ActiveJobs      func() ([]dogeboxd.JobRecord, error)
 	ReadFile        func(string) ([]byte, error)
 	RepoTagsFetcher system.RepoTagsFetcher
 }
@@ -19,13 +20,8 @@ type Migration struct {
 	Name         string
 	DisplayName  string
 	Version      string
-	RunPolicy    RunPolicy
 	Requirements func(Context, MigrationRecord) (bool, string, error)
 	Run          func(Context, MigrationRecord) (string, bool, error)
-}
-
-type RunPolicy struct {
-	MaxRuns int
 }
 
 type RunDecision struct {
@@ -50,9 +46,19 @@ func (c Context) RepoTagsFetcherOrDefault() system.RepoTagsFetcher {
 	return &system.DefaultRepoTagsFetcher{}
 }
 
+func (c Context) ActiveJobsOrDefault() func() ([]dogeboxd.JobRecord, error) {
+	if c.ActiveJobs != nil {
+		return c.ActiveJobs
+	}
+
+	return func() ([]dogeboxd.JobRecord, error) {
+		return nil, nil
+	}
+}
+
 func RunMigrations(ctx Context, migrations []Migration) (string, bool, error) {
 	for _, migration := range migrations {
-		decision, err := EvaluateRunDecision(ctx.Config, migration.Name, migration.RunPolicy)
+		decision, err := EvaluateRunDecision(ctx.Config, migration.Name)
 		if err != nil {
 			return "", false, err
 		}
@@ -87,10 +93,6 @@ func RunMigrations(ctx Context, migrations []Migration) (string, bool, error) {
 			continue
 		}
 
-		if err := RecordRun(ctx.Config, migration.Name); err != nil {
-			return jobID, true, err
-		}
-
 		log.Printf("Queued startup %s job: %s", migration.DisplayName, jobID)
 		return jobID, true, nil
 	}
@@ -98,26 +100,26 @@ func RunMigrations(ctx Context, migrations []Migration) (string, bool, error) {
 	return "", false, nil
 }
 
-func EvaluateRunDecision(config dogeboxd.ServerConfig, migrationName string, policy RunPolicy) (RunDecision, error) {
+func EvaluateRunDecision(config dogeboxd.ServerConfig, migrationName string) (RunDecision, error) {
 	state, err := LoadState(config)
 	if err != nil {
 		return RunDecision{}, err
 	}
 
 	record := state[migrationName]
+	if record.RanSuccessfully {
+		return RunDecision{
+			Record:     record,
+			ShouldRun:  false,
+			SkipReason: "migration has already run successfully",
+		}, nil
+	}
+
 	if record.DoNotRun {
 		return RunDecision{
 			Record:     record,
 			ShouldRun:  false,
 			SkipReason: "migrations.json has doNotRun=true",
-		}, nil
-	}
-
-	if policy.MaxRuns > 0 && record.Runs >= policy.MaxRuns {
-		return RunDecision{
-			Record:     record,
-			ShouldRun:  false,
-			SkipReason: "it has already run the maximum allowed number of times",
 		}, nil
 	}
 

--- a/pkg/system/migrations/core/runner_test.go
+++ b/pkg/system/migrations/core/runner_test.go
@@ -35,7 +35,6 @@ func TestRunMigrationsSkipsDoNotRun(t *testing.T) {
 		{
 			Name:        "skip_do_not_run",
 			DisplayName: "Skip Do Not Run",
-			RunPolicy:   RunPolicy{MaxRuns: 1},
 			Run: func(Context, MigrationRecord) (string, bool, error) {
 				ran = true
 				return "", false, nil
@@ -56,7 +55,7 @@ func TestRunMigrationsSkipsDoNotRun(t *testing.T) {
 func TestEvaluateRunDecisionAllowsMissingRecord(t *testing.T) {
 	ctx := testMigrationContext(t)
 
-	decision, err := EvaluateRunDecision(ctx.Config, "test_migration", RunPolicy{MaxRuns: 1})
+	decision, err := EvaluateRunDecision(ctx.Config, "test_migration")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -75,7 +74,7 @@ func TestEvaluateRunDecisionSkipsWhenDoNotRunSet(t *testing.T) {
 		t.Fatalf("expected save to succeed, got %v", err)
 	}
 
-	decision, err := EvaluateRunDecision(ctx.Config, "test_migration", RunPolicy{MaxRuns: 1})
+	decision, err := EvaluateRunDecision(ctx.Config, "test_migration")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -84,66 +83,32 @@ func TestEvaluateRunDecisionSkipsWhenDoNotRunSet(t *testing.T) {
 	}
 }
 
-func TestEvaluateRunDecisionSkipsWhenRunLimitReached(t *testing.T) {
+func TestEvaluateRunDecisionSkipsWhenRanSuccessfullySet(t *testing.T) {
 	ctx := testMigrationContext(t)
 	if err := SaveState(ctx.Config, State{
 		"test_migration": {
-			Runs: 1,
+			RanSuccessfully: true,
 		},
 	}); err != nil {
 		t.Fatalf("expected save to succeed, got %v", err)
 	}
 
-	decision, err := EvaluateRunDecision(ctx.Config, "test_migration", RunPolicy{MaxRuns: 1})
+	decision, err := EvaluateRunDecision(ctx.Config, "test_migration")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if decision.ShouldRun || decision.SkipReason == "" {
-		t.Fatalf("expected run limit to skip with a reason, got %+v", decision)
+		t.Fatalf("expected ranSuccessfully to skip with a reason, got %+v", decision)
 	}
 }
 
-func TestRunMigrationsSkipsWhenMaxRunsReached(t *testing.T) {
-	ctx := testMigrationContext(t)
-	if err := SaveState(ctx.Config, State{
-		"skip_max_runs": {
-			Runs: 1,
-		},
-	}); err != nil {
-		t.Fatalf("expected save to succeed, got %v", err)
-	}
-
-	ran := false
-	jobID, queued, err := RunMigrations(ctx, []Migration{
-		{
-			Name:        "skip_max_runs",
-			DisplayName: "Skip Max Runs",
-			RunPolicy:   RunPolicy{MaxRuns: 1},
-			Run: func(Context, MigrationRecord) (string, bool, error) {
-				ran = true
-				return "", false, nil
-			},
-		},
-	})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if queued || jobID != "" {
-		t.Fatalf("expected no queued migration, got queued=%v jobID=%q", queued, jobID)
-	}
-	if ran {
-		t.Fatal("expected max-runs migration to be skipped before Run")
-	}
-}
-
-func TestRunMigrationsRecordsRunOnlyWhenQueued(t *testing.T) {
+func TestRunMigrationsDoesNotMarkSuccessWhenQueued(t *testing.T) {
 	ctx := testMigrationContext(t)
 
 	jobID, queued, err := RunMigrations(ctx, []Migration{
 		{
 			Name:        "records_run",
 			DisplayName: "Records Run",
-			RunPolicy:   RunPolicy{MaxRuns: 1},
 			Run: func(Context, MigrationRecord) (string, bool, error) {
 				return "job-records-run", true, nil
 			},
@@ -160,8 +125,8 @@ func TestRunMigrationsRecordsRunOnlyWhenQueued(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected load to succeed, got %v", err)
 	}
-	if state["records_run"].Runs != 1 {
-		t.Fatalf("expected run count of 1, got %+v", state["records_run"])
+	if state["records_run"].RanSuccessfully {
+		t.Fatalf("expected queued migration to leave success state unchanged, got %+v", state["records_run"])
 	}
 }
 
@@ -173,7 +138,6 @@ func TestRunMigrationsStopsAfterFirstQueuedMigration(t *testing.T) {
 		{
 			Name:        "first",
 			DisplayName: "First",
-			RunPolicy:   RunPolicy{MaxRuns: 1},
 			Run: func(Context, MigrationRecord) (string, bool, error) {
 				return "job-first", true, nil
 			},
@@ -181,7 +145,6 @@ func TestRunMigrationsStopsAfterFirstQueuedMigration(t *testing.T) {
 		{
 			Name:        "second",
 			DisplayName: "Second",
-			RunPolicy:   RunPolicy{MaxRuns: 1},
 			Run: func(Context, MigrationRecord) (string, bool, error) {
 				secondRan = true
 				return "", false, nil
@@ -207,7 +170,6 @@ func TestRunMigrationsContinuesAfterNonQueuedMigration(t *testing.T) {
 		{
 			Name:        "first_non_queued",
 			DisplayName: "First Non Queued",
-			RunPolicy:   RunPolicy{MaxRuns: 1},
 			Run: func(Context, MigrationRecord) (string, bool, error) {
 				return "", false, nil
 			},
@@ -215,7 +177,6 @@ func TestRunMigrationsContinuesAfterNonQueuedMigration(t *testing.T) {
 		{
 			Name:        "second_queued",
 			DisplayName: "Second Queued",
-			RunPolicy:   RunPolicy{MaxRuns: 1},
 			Run: func(Context, MigrationRecord) (string, bool, error) {
 				secondRan = true
 				return "job-second", true, nil

--- a/pkg/system/migrations/core/state.go
+++ b/pkg/system/migrations/core/state.go
@@ -11,9 +11,9 @@ import (
 const migrationsStateFilename = "migrations.json"
 
 type MigrationRecord struct {
-	Runs     int            `json:"runs"`
-	DoNotRun bool           `json:"doNotRun"`
-	Config   map[string]any `json:"config,omitempty"`
+	RanSuccessfully bool           `json:"ranSuccessfully"`
+	DoNotRun        bool           `json:"doNotRun"`
+	Config          map[string]any `json:"config,omitempty"`
 }
 
 type State map[string]MigrationRecord
@@ -81,19 +81,6 @@ func SaveState(config dogeboxd.ServerConfig, state State) error {
 	return os.Rename(tempPath, statePath)
 }
 
-func RecordRun(config dogeboxd.ServerConfig, migrationName string) error {
-	state, err := LoadState(config)
-	if err != nil {
-		return err
-	}
-
-	record := state[migrationName]
-	record.Runs++
-	state[migrationName] = record
-
-	return SaveState(config, state)
-}
-
 func SetDoNotRun(config dogeboxd.ServerConfig, migrationName string, value bool) error {
 	state, err := LoadState(config)
 	if err != nil {
@@ -102,6 +89,33 @@ func SetDoNotRun(config dogeboxd.ServerConfig, migrationName string, value bool)
 
 	record := state[migrationName]
 	record.DoNotRun = value
+	state[migrationName] = record
+
+	return SaveState(config, state)
+}
+
+func SetRanSuccessfully(config dogeboxd.ServerConfig, migrationName string, value bool) error {
+	state, err := LoadState(config)
+	if err != nil {
+		return err
+	}
+
+	record := state[migrationName]
+	record.RanSuccessfully = value
+	state[migrationName] = record
+
+	return SaveState(config, state)
+}
+
+func MarkCompleted(config dogeboxd.ServerConfig, migrationName string) error {
+	state, err := LoadState(config)
+	if err != nil {
+		return err
+	}
+
+	record := state[migrationName]
+	record.RanSuccessfully = true
+	record.DoNotRun = true
 	state[migrationName] = record
 
 	return SaveState(config, state)

--- a/pkg/system/migrations/core/state_test.go
+++ b/pkg/system/migrations/core/state_test.go
@@ -25,8 +25,8 @@ func TestSaveStatePreservesUnknownKeys(t *testing.T) {
 
 	input := State{
 		"unknown_migration": {
-			Runs:     2,
-			DoNotRun: true,
+			RanSuccessfully: true,
+			DoNotRun:        true,
 			Config: map[string]any{
 				"exampleFlag": true,
 				"mode":        "test",
@@ -46,12 +46,11 @@ func TestSaveStatePreservesUnknownKeys(t *testing.T) {
 	}
 }
 
-func TestRecordRunIncrementsWithoutClearingFlagsOrConfig(t *testing.T) {
+func TestSetRanSuccessfullyWithoutClearingFlagsOrConfig(t *testing.T) {
 	config := dogeboxd.ServerConfig{DataDir: t.TempDir()}
 
 	if err := SaveState(config, State{
 		"test_migration": {
-			Runs:     1,
 			DoNotRun: true,
 			Config: map[string]any{
 				"exampleFlag": true,
@@ -61,8 +60,8 @@ func TestRecordRunIncrementsWithoutClearingFlagsOrConfig(t *testing.T) {
 		t.Fatalf("expected save to succeed, got %v", err)
 	}
 
-	if err := RecordRun(config, "test_migration"); err != nil {
-		t.Fatalf("expected record run to succeed, got %v", err)
+	if err := SetRanSuccessfully(config, "test_migration", true); err != nil {
+		t.Fatalf("expected set ran successfully to succeed, got %v", err)
 	}
 
 	state, err := LoadState(config)
@@ -70,8 +69,35 @@ func TestRecordRunIncrementsWithoutClearingFlagsOrConfig(t *testing.T) {
 		t.Fatalf("expected load to succeed, got %v", err)
 	}
 	record := state["test_migration"]
-	if record.Runs != 2 || !record.DoNotRun || !record.BoolConfig("exampleFlag") {
-		t.Fatalf("expected incremented runs and preserved flags/config, got %+v", record)
+	if !record.RanSuccessfully || !record.DoNotRun || !record.BoolConfig("exampleFlag") {
+		t.Fatalf("expected ranSuccessfully and preserved flags/config, got %+v", record)
+	}
+}
+
+func TestMarkCompletedSetsTerminalFlagsWithoutClearingConfig(t *testing.T) {
+	config := dogeboxd.ServerConfig{DataDir: t.TempDir()}
+
+	if err := SaveState(config, State{
+		"test_migration": {
+			Config: map[string]any{
+				"exampleFlag": true,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("expected save to succeed, got %v", err)
+	}
+
+	if err := MarkCompleted(config, "test_migration"); err != nil {
+		t.Fatalf("expected mark completed to succeed, got %v", err)
+	}
+
+	state, err := LoadState(config)
+	if err != nil {
+		t.Fatalf("expected load to succeed, got %v", err)
+	}
+	record := state["test_migration"]
+	if !record.RanSuccessfully || !record.DoNotRun || !record.BoolConfig("exampleFlag") {
+		t.Fatalf("expected completed flags and preserved config, got %+v", record)
 	}
 }
 

--- a/pkg/system/migrations/definitions/os_flake.go
+++ b/pkg/system/migrations/definitions/os_flake.go
@@ -2,18 +2,20 @@ package definitions
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"regexp"
 
 	dogeboxd "github.com/Dogebox-WG/dogeboxd/pkg"
 	"github.com/Dogebox-WG/dogeboxd/pkg/system"
 	"github.com/Dogebox-WG/dogeboxd/pkg/system/migrations/core"
+	"github.com/Dogebox-WG/dogeboxd/pkg/version"
 )
 
-const installedOSFlakePath = "/etc/nixos/flake.nix"
+var installedOSFlakePath = "/etc/nixos/flake.nix"
+
 const osFlakeIncludePreReleasesConfigKey = "includePreReleases"
 
-var osFlakeMigrationRunPolicy = core.RunPolicy{MaxRuns: 1}
 var osFlakeMigrationMetadata = struct {
 	Name    string
 	Version string
@@ -26,7 +28,6 @@ var OSFlakeMigration = core.Migration{
 	Name:         osFlakeMigrationMetadata.Name,
 	DisplayName:  "OS flake migrator",
 	Version:      osFlakeMigrationMetadata.Version,
-	RunPolicy:    osFlakeMigrationRunPolicy,
 	Requirements: osFlakeMigrationRequirements,
 	Run:          runOSFlakeMigration,
 }
@@ -41,10 +42,18 @@ var OSFlakeMigration = core.Migration{
 //  2. require an installed OS flake version matching <=v0.9.0-rc.1,
 //  3. select the latest eligible OS release,
 //  4. compare that target against the installed OS flake version,
-//  5. queue the normal SystemUpdate path once, and
-//  6. record a run in migrations.json so startup does not loop.
+//  5. queue the normal SystemUpdate path when the target OS flake still needs to land.
 
 var osFlakeVersionPattern = regexp.MustCompile(`(?m)^\s*dbxRelease\s*=\s*"(v[^"]+)"`)
+
+type osFlakeMigrationDecision struct {
+	installedFlakeVersion string
+	currentDBXRelease     string
+	targetVersion         string
+	includePreReleases    bool
+	complete              bool
+	reason                string
+}
 
 func getInstalledOSFlakeVersion(readFile func(string) ([]byte, error), flakePath string) (string, error) {
 	flakeContents, err := readFile(flakePath)
@@ -62,77 +71,184 @@ func getInstalledOSFlakeVersion(readFile func(string) ([]byte, error), flakePath
 	return match[1], nil
 }
 
+func semverIsAtOrAbove(version string, threshold string) (bool, error) {
+	if version == "" {
+		return false, nil
+	}
+
+	return core.VersionConstraintCheck(version, ">="+threshold)
+}
+
+func isOSFlakeMigrationComplete(installedFlakeVersion string, currentDBXRelease string) (bool, error) {
+	for _, candidate := range []string{installedFlakeVersion, currentDBXRelease} {
+		ok, err := semverIsAtOrAbove(candidate, osFlakeMigrationMetadata.Version)
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
 func osFlakeMigrationRequirements(ctx core.Context, record core.MigrationRecord) (bool, string, error) {
 	if ctx.Config.Recovery {
 		return false, "running in recovery mode", nil
 	}
 
-	_, _, applies, reason, err := determineOSFlakeMigrationTarget(ctx, record)
+	decision, err := determineOSFlakeMigrationDecision(ctx, record, true)
 	if err != nil {
 		return false, "", err
 	}
-	if !applies {
-		return false, reason, nil
+	if decision.complete {
+		if err := core.MarkCompleted(ctx.Config, osFlakeMigrationMetadata.Name); err != nil {
+			return false, "", err
+		}
+		log.Printf(
+			"OS flake migrator marking migration complete after verifying target state: installed OS flake=%s, current DBX release=%s",
+			decision.installedFlakeVersion,
+			decision.currentDBXRelease,
+		)
+		return false, "verified target state already satisfies the migration", nil
+	}
+	if decision.reason != "" {
+		return false, decision.reason, nil
 	}
 
 	return true, "", nil
 }
 
 func runOSFlakeMigration(ctx core.Context, record core.MigrationRecord) (string, bool, error) {
-	_, targetVersion, applies, _, err := determineOSFlakeMigrationTarget(ctx, record)
+	decision, err := determineOSFlakeMigrationDecision(ctx, record, false)
 	if err != nil {
 		return "", false, err
 	}
-	if !applies {
+	if decision.complete {
+		return "", false, nil
+	}
+
+	activeJobs, err := ctx.ActiveJobsOrDefault()()
+	if err != nil {
+		return "", false, err
+	}
+	for _, job := range activeJobs {
+		if job.Action == (dogeboxd.SystemUpdate{}).ActionName() {
+			log.Printf("Skipping OS flake migrator queue because active job %s (%s) is already %s", job.ID, job.Action, job.Status)
+			return "", false, nil
+		}
+	}
+
+	if decision.targetVersion == "" {
 		return "", false, nil
 	}
 
 	jobID := ctx.Enqueue(dogeboxd.SystemUpdate{
 		Package: "os",
-		Version: targetVersion,
+		Version: decision.targetVersion,
 	})
 
 	return jobID, true, nil
 }
 
-func determineOSFlakeMigrationTarget(ctx core.Context, record core.MigrationRecord) (string, string, bool, string, error) {
+func determineOSFlakeMigrationDecision(ctx core.Context, record core.MigrationRecord, logDiscovery bool) (osFlakeMigrationDecision, error) {
 	installedFlakeVersion, err := getInstalledOSFlakeVersion(ctx.ReadFileOrDefault(), installedOSFlakePath)
 	if err != nil {
-		return "", "", false, "", err
+		return osFlakeMigrationDecision{}, err
+	}
+
+	currentDBXRelease := version.GetDBXRelease().Release
+
+	includePreReleases := record.BoolConfig(osFlakeIncludePreReleasesConfigKey)
+	complete, err := isOSFlakeMigrationComplete(installedFlakeVersion, currentDBXRelease)
+	if err != nil {
+		return osFlakeMigrationDecision{}, err
+	}
+
+	decision := osFlakeMigrationDecision{
+		installedFlakeVersion: installedFlakeVersion,
+		currentDBXRelease:     currentDBXRelease,
+		includePreReleases:    includePreReleases,
+		complete:              complete,
+	}
+
+	if complete {
+		return decision, nil
+	}
+
+	releases, err := system.GetUpgradableReleasesForVersionWithFetcher(currentDBXRelease, includePreReleases, ctx.RepoTagsFetcherOrDefault())
+	if err != nil {
+		return osFlakeMigrationDecision{}, err
+	}
+	if logDiscovery {
+		latestEligibleRelease := "none"
+		if len(releases) > 0 {
+			latestEligibleRelease = releases[0].Version
+		}
+		log.Printf(
+			"OS flake migrator release discovery: installed OS flake=%s, current DBX release=%s, includePreReleases=%t, latest eligible OS release=%s",
+			installedFlakeVersion,
+			currentDBXRelease,
+			includePreReleases,
+			latestEligibleRelease,
+		)
 	}
 
 	matchesInstalledVersionConstraint, err := core.VersionConstraintCheck(installedFlakeVersion, "<="+osFlakeMigrationMetadata.Version)
 	if err != nil {
-		return "", "", false, "", err
+		return osFlakeMigrationDecision{}, err
 	}
 	if !matchesInstalledVersionConstraint {
-		return installedFlakeVersion, "", false, fmt.Sprintf("installed OS flake version %s is newer than %s", installedFlakeVersion, osFlakeMigrationMetadata.Version), nil
+		decision.reason = fmt.Sprintf("installed OS flake version %s is newer than %s", installedFlakeVersion, osFlakeMigrationMetadata.Version)
+		return decision, nil
 	}
 
-	releases, err := system.GetUpgradableReleasesWithFetcher(record.BoolConfig(osFlakeIncludePreReleasesConfigKey), ctx.RepoTagsFetcherOrDefault())
+	currentReleaseInMigrationRange, err := semverIsAtOrAbove(currentDBXRelease, osFlakeMigrationMetadata.Version)
 	if err != nil {
-		return installedFlakeVersion, "", false, "", err
+		return osFlakeMigrationDecision{}, err
 	}
+	if currentReleaseInMigrationRange {
+		// A partial activation can update DBX while leaving /etc/nixos on the
+		// old flake. Re-run the current release so activation can copy the
+		// staged flake into place and let the next startup mark this complete.
+		decision.targetVersion = currentDBXRelease
+		return decision, nil
+	}
+
 	if len(releases) == 0 {
-		return installedFlakeVersion, "", false, fmt.Sprintf("no eligible OS releases are available for %s", osFlakeMigrationMetadata.Version), nil
+		preReleasePolicy := "pre-releases excluded"
+		if includePreReleases {
+			preReleasePolicy = "pre-releases included"
+		}
+		decision.reason = fmt.Sprintf("no eligible OS releases are available newer than current DBX release %s (%s)", currentDBXRelease, preReleasePolicy)
+		return decision, nil
 	}
 
 	targetVersion := releases[0].Version
 	targetIsNewer, err := core.VersionConstraintCheck(installedFlakeVersion, "<"+targetVersion)
 	if err != nil {
-		return installedFlakeVersion, targetVersion, false, "", err
+		return osFlakeMigrationDecision{}, err
 	}
 	if !targetIsNewer {
-		return installedFlakeVersion, targetVersion, false, fmt.Sprintf("installed OS flake version %s is not older than inferred target %s", installedFlakeVersion, targetVersion), nil
+		decision.targetVersion = targetVersion
+		decision.reason = fmt.Sprintf("installed OS flake version %s is not older than inferred target %s", installedFlakeVersion, targetVersion)
+		return decision, nil
 	}
 
-	return installedFlakeVersion, targetVersion, true, "", nil
+	decision.targetVersion = targetVersion
+	return decision, nil
 }
 
-func QueueOSFlakeMigratorIfNeeded(config dogeboxd.ServerConfig, enqueue func(dogeboxd.Action) string) (string, bool, error) {
+func QueueOSFlakeMigratorIfNeeded(
+	config dogeboxd.ServerConfig,
+	enqueue func(dogeboxd.Action) string,
+	activeJobs func() ([]dogeboxd.JobRecord, error),
+) (string, bool, error) {
 	return core.RunMigrations(core.Context{
 		Config:          config,
 		Enqueue:         enqueue,
+		ActiveJobs:      activeJobs,
 		ReadFile:        os.ReadFile,
 		RepoTagsFetcher: &system.DefaultRepoTagsFetcher{},
 	}, []core.Migration{OSFlakeMigration})

--- a/pkg/system/migrations/definitions/os_flake_test.go
+++ b/pkg/system/migrations/definitions/os_flake_test.go
@@ -2,6 +2,8 @@ package definitions
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	dogeboxd "github.com/Dogebox-WG/dogeboxd/pkg"
@@ -18,64 +20,47 @@ func (m mockRepoTagsFetcher) GetRepoTags(string) ([]system.RepositoryTag, error)
 	return m.tags, m.err
 }
 
-func testOSFlakeReadFile(version string) func(string) ([]byte, error) {
-	return func(string) ([]byte, error) {
-		return []byte(fmt.Sprintf(`{
-  dbxRelease = %q;
-}`, version)), nil
+func testOSFlakeReadFiles(files map[string]string) func(string) ([]byte, error) {
+	return func(path string) ([]byte, error) {
+		content, ok := files[path]
+		if !ok {
+			return nil, os.ErrNotExist
+		}
+		return []byte(content), nil
 	}
 }
 
-func TestOSFlakeMigrationRequirementsAllowEligibleInstalledVersions(t *testing.T) {
-	testCases := []struct {
-		name                  string
-		installedFlakeVersion string
-	}{
-		{
-			name:                  "pre 0.9 installed flake",
-			installedFlakeVersion: "v0.8.1",
-		},
-		{
-			name:                  "0.9 prerelease installed flake",
-			installedFlakeVersion: "v0.9.0-rc.1",
-		},
+func setupTestDBXRelease(t *testing.T, currentRelease string) {
+	t.Helper()
+
+	versionDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(versionDir, "dbx"), []byte(currentRelease+"\n"), 0644); err != nil {
+		t.Fatalf("failed to write test dbx release: %v", err)
 	}
+	t.Setenv("VERSION_PATH_OVERRIDE", versionDir)
+}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := core.Context{
-				Config: dogeboxd.ServerConfig{
-					DataDir: t.TempDir(),
-					TmpDir:  t.TempDir(),
-				},
-				ReadFile: testOSFlakeReadFile(tc.installedFlakeVersion),
-				RepoTagsFetcher: mockRepoTagsFetcher{
-					tags: []system.RepositoryTag{
-						{Tag: "v1.2.0-rc.1"},
-						{Tag: "v1.2.0"},
-						{Tag: "v1.1.0"},
-					},
-				},
-			}
+func testFlakeVersionFile(version string) string {
+	return fmt.Sprintf(`{
+  dbxRelease = %q;
+}`, version)
+}
 
-			applies, reason, err := OSFlakeMigration.Requirements(ctx, core.MigrationRecord{})
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-			if !applies {
-				t.Fatalf("expected migration to apply, got reason %q", reason)
-			}
-		})
+func testOSFlakeFiles(installedVersion string) map[string]string {
+	return map[string]string{
+		installedOSFlakePath: testFlakeVersionFile(installedVersion),
 	}
 }
 
 func TestOSFlakeMigrationRequirementsSkipWhenInstalledVersionIsAfterConstraint(t *testing.T) {
+	setupTestDBXRelease(t, "v0.9.0")
+
 	ctx := core.Context{
 		Config: dogeboxd.ServerConfig{
 			DataDir: t.TempDir(),
 			TmpDir:  t.TempDir(),
 		},
-		ReadFile: testOSFlakeReadFile("v0.9.0"),
+		ReadFile: testOSFlakeReadFiles(testOSFlakeFiles("v0.9.0")),
 		RepoTagsFetcher: mockRepoTagsFetcher{
 			tags: []system.RepositoryTag{
 				{Tag: "v1.2.0"},
@@ -83,25 +68,35 @@ func TestOSFlakeMigrationRequirementsSkipWhenInstalledVersionIsAfterConstraint(t
 		},
 	}
 
-	applies, reason, err := OSFlakeMigration.Requirements(ctx, core.MigrationRecord{})
+	applies, _, err := OSFlakeMigration.Requirements(ctx, core.MigrationRecord{})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if applies {
 		t.Fatal("expected installed version after constraint to skip migration")
 	}
-	if reason == "" {
-		t.Fatal("expected skip reason")
+
+	state, err := core.LoadState(ctx.Config)
+	if err != nil {
+		t.Fatalf("expected load to succeed, got %v", err)
+	}
+	if !state[osFlakeMigrationMetadata.Name].DoNotRun {
+		t.Fatalf("expected migration to mark doNotRun after verified completion, got %+v", state[osFlakeMigrationMetadata.Name])
+	}
+	if !state[osFlakeMigrationMetadata.Name].RanSuccessfully {
+		t.Fatalf("expected migration to mark ranSuccessfully after verified completion, got %+v", state[osFlakeMigrationMetadata.Name])
 	}
 }
 
 func TestOSFlakeMigrationRequirementsSkipWhenNoStableReleaseAvailable(t *testing.T) {
+	setupTestDBXRelease(t, "v0.8.1")
+
 	ctx := core.Context{
 		Config: dogeboxd.ServerConfig{
 			DataDir: t.TempDir(),
 			TmpDir:  t.TempDir(),
 		},
-		ReadFile: testOSFlakeReadFile("v0.9.0-rc.1"),
+		ReadFile: testOSFlakeReadFiles(testOSFlakeFiles("v0.9.0-rc.1")),
 		RepoTagsFetcher: mockRepoTagsFetcher{
 			tags: []system.RepositoryTag{
 				{Tag: "v1.2.0-rc.1"},
@@ -119,60 +114,20 @@ func TestOSFlakeMigrationRequirementsSkipWhenNoStableReleaseAvailable(t *testing
 	if reason == "" {
 		t.Fatal("expected skip reason")
 	}
-}
-
-func TestRunOSFlakeMigrationQueuesLatestStableUpdate(t *testing.T) {
-	ctx := core.Context{
-		Config: dogeboxd.ServerConfig{
-			DataDir: t.TempDir(),
-			TmpDir:  t.TempDir(),
-		},
-		ReadFile: testOSFlakeReadFile("v0.8.1"),
-		RepoTagsFetcher: mockRepoTagsFetcher{
-			tags: []system.RepositoryTag{
-				{Tag: "v1.2.0-rc.1"},
-				{Tag: "v1.2.0"},
-				{Tag: "v1.1.0"},
-			},
-		},
-	}
-
-	var queuedActions []dogeboxd.Action
-	ctx.Enqueue = func(action dogeboxd.Action) string {
-		queuedActions = append(queuedActions, action)
-		return "job-123"
-	}
-
-	jobID, queued, err := OSFlakeMigration.Run(ctx, core.MigrationRecord{})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if !queued {
-		t.Fatal("expected migration to queue an update")
-	}
-	if jobID != "job-123" {
-		t.Fatalf("expected job-123, got %s", jobID)
-	}
-	if len(queuedActions) != 1 {
-		t.Fatalf("expected exactly one queued action, got %d", len(queuedActions))
-	}
-
-	update, ok := queuedActions[0].(dogeboxd.SystemUpdate)
-	if !ok {
-		t.Fatalf("expected SystemUpdate action, got %T", queuedActions[0])
-	}
-	if update.Package != "os" || update.Version != "v1.2.0" {
-		t.Fatalf("unexpected queued update: %+v", update)
+	if reason != "no eligible OS releases are available newer than current DBX release v0.8.1 (pre-releases excluded)" {
+		t.Fatalf("expected skip reason to reference current DBX release, got %q", reason)
 	}
 }
 
 func TestRunOSFlakeMigrationQueuesLatestPrereleaseWhenEnabled(t *testing.T) {
+	setupTestDBXRelease(t, "v0.8.1")
+
 	ctx := core.Context{
 		Config: dogeboxd.ServerConfig{
 			DataDir: t.TempDir(),
 			TmpDir:  t.TempDir(),
 		},
-		ReadFile: testOSFlakeReadFile("v0.9.0-rc.1"),
+		ReadFile: testOSFlakeReadFiles(testOSFlakeFiles("v0.8.1")),
 		RepoTagsFetcher: mockRepoTagsFetcher{
 			tags: []system.RepositoryTag{
 				{Tag: "v1.3.0-rc.2"},
@@ -212,5 +167,92 @@ func TestRunOSFlakeMigrationQueuesLatestPrereleaseWhenEnabled(t *testing.T) {
 	}
 	if update.Package != "os" || update.Version != "v1.3.0-rc.2" {
 		t.Fatalf("unexpected queued update: %+v", update)
+	}
+}
+
+func TestRunOSFlakeMigrationQueuesCurrentReleaseWhenDBXUpdatedButFlakeIsStale(t *testing.T) {
+	setupTestDBXRelease(t, "v0.9.0-rc.8")
+
+	ctx := core.Context{
+		Config: dogeboxd.ServerConfig{
+			DataDir: t.TempDir(),
+			TmpDir:  t.TempDir(),
+		},
+		ReadFile:        testOSFlakeReadFiles(testOSFlakeFiles("v0.8.2")),
+		RepoTagsFetcher: mockRepoTagsFetcher{},
+	}
+
+	var queuedActions []dogeboxd.Action
+	ctx.Enqueue = func(action dogeboxd.Action) string {
+		queuedActions = append(queuedActions, action)
+		return "job-current-release"
+	}
+
+	jobID, queued, err := OSFlakeMigration.Run(ctx, core.MigrationRecord{
+		Config: map[string]any{
+			osFlakeIncludePreReleasesConfigKey: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !queued {
+		t.Fatal("expected migration to queue a current-release repair update")
+	}
+	if jobID != "job-current-release" {
+		t.Fatalf("expected job-current-release, got %s", jobID)
+	}
+	if len(queuedActions) != 1 {
+		t.Fatalf("expected exactly one queued action, got %d", len(queuedActions))
+	}
+
+	update, ok := queuedActions[0].(dogeboxd.SystemUpdate)
+	if !ok {
+		t.Fatalf("expected SystemUpdate action, got %T", queuedActions[0])
+	}
+	if update.Package != "os" || update.Version != "v0.9.0-rc.8" {
+		t.Fatalf("unexpected queued update: %+v", update)
+	}
+}
+
+func TestRunOSFlakeMigrationSkipsWhenSystemJobAlreadyActive(t *testing.T) {
+	setupTestDBXRelease(t, "v0.8.1")
+
+	enqueued := false
+	ctx := core.Context{
+		Config: dogeboxd.ServerConfig{
+			DataDir: t.TempDir(),
+			TmpDir:  t.TempDir(),
+		},
+		ReadFile: testOSFlakeReadFiles(testOSFlakeFiles("v0.8.1")),
+		RepoTagsFetcher: mockRepoTagsFetcher{
+			tags: []system.RepositoryTag{
+				{Tag: "v0.9.0-rc.8"},
+			},
+		},
+		ActiveJobs: func() ([]dogeboxd.JobRecord, error) {
+			return []dogeboxd.JobRecord{
+				{
+					ID:     "job-1",
+					Action: dogeboxd.SystemUpdate{}.ActionName(),
+					Status: dogeboxd.JobStatusInProgress,
+				},
+			}, nil
+		},
+		Enqueue: func(action dogeboxd.Action) string {
+			enqueued = true
+			return "job-should-not-queue"
+		},
+	}
+
+	jobID, queued, err := OSFlakeMigration.Run(ctx, core.MigrationRecord{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if queued || jobID != "" {
+		t.Fatalf("expected migration to skip duplicate active work, got queued=%v jobID=%q", queued, jobID)
+	}
+	if enqueued {
+		t.Fatal("expected migration not to enqueue while system job is active")
 	}
 }

--- a/pkg/system/test_helpers_test.go
+++ b/pkg/system/test_helpers_test.go
@@ -13,7 +13,7 @@ func AssertUpgradableRelease(t *testing.T, release UpgradableRelease, expectedVe
 		t.Errorf("Expected version %s, got %s", expectedVersion, release.Version)
 	}
 
-	expectedURL := fmt.Sprintf("https://github.com/dogebox-wg/os/releases/tag/%s", expectedVersion)
+	expectedURL := "https://github.com/dogebox-wg/os/releases/tag/" + expectedVersion
 	if release.ReleaseURL != expectedURL {
 		t.Errorf("Expected release URL %s, got %s", expectedURL, release.ReleaseURL)
 	}

--- a/pkg/system/upgrades.go
+++ b/pkg/system/upgrades.go
@@ -21,6 +21,7 @@ import (
 
 var RELEASE_REPOSITORY = "https://github.com/dogebox-wg/os.git"
 var SUDO_COMMAND = "sudo"
+var DBXROOT_WRAPPER_COMMAND = "/run/wrappers/bin/_dbxroot"
 
 // semverSortTags sorts a slice of RepositoryTag by semver version
 // direction: "desc" for descending (highest first), "asc" for ascending (lowest first)
@@ -119,7 +120,10 @@ func GetUpgradableReleases(includePreReleases bool) ([]UpgradableRelease, error)
 
 func GetUpgradableReleasesWithFetcher(includePreReleases bool, fetcher RepoTagsFetcher) ([]UpgradableRelease, error) {
 	dbxRelease := version.GetDBXRelease()
+	return GetUpgradableReleasesForVersionWithFetcher(dbxRelease.Release, includePreReleases, fetcher)
+}
 
+func GetUpgradableReleasesForVersionWithFetcher(currentRelease string, includePreReleases bool, fetcher RepoTagsFetcher) ([]UpgradableRelease, error) {
 	tags, err := fetcher.GetRepoTags(RELEASE_REPOSITORY)
 	if err != nil {
 		return []UpgradableRelease{}, err
@@ -133,7 +137,7 @@ func GetUpgradableReleasesWithFetcher(includePreReleases bool, fetcher RepoTagsF
 			Summary:    "Update for Dogeboxd / DKM / DPanel",
 		}
 
-		if semver.Compare(tag.Tag, dbxRelease.Release) > 0 {
+		if semver.Compare(tag.Tag, currentRelease) > 0 {
 			// If not including pre-releases, filter out pre-release versions
 			if !includePreReleases && semver.Prerelease(tag.Tag) != "" {
 				continue
@@ -179,18 +183,57 @@ func buildStagedReleaseDirPath(tmpDir string, updateVersion string, commitHash s
 	return filepath.Join(tmpDir, fmt.Sprintf("os-upgrade-%s-%s", updateVersion, commitHash))
 }
 
-func stageReleaseFlake(tmpDir, updateVersion string, logger dogeboxd.SubLogger) (string, error) {
+func sanitizeSystemdUnitComponent(value string) string {
+	sanitizer := strings.NewReplacer(".", "-", "/", "-", " ", "-", ":", "-", "@", "-", "+", "-", "=", "-")
+	return sanitizer.Replace(value)
+}
+
+func shortCommitHash(commitHash string) string {
+	if len(commitHash) <= 8 {
+		return commitHash
+	}
+
+	return commitHash[:8]
+}
+
+func buildSystemUpdateUnitName(updateVersion string, commitHash string) string {
+	unitName := fmt.Sprintf("dogebox-system-update-%s", sanitizeSystemdUnitComponent(updateVersion))
+	if commitHash != "" {
+		unitName = fmt.Sprintf("%s-%s", unitName, sanitizeSystemdUnitComponent(shortCommitHash(commitHash)))
+	}
+	return unitName
+}
+
+func buildSystemUpdateCommandArgs(stagedFlakeDir string, updateVersion string, unitName string) []string {
+	return []string{
+		DBXROOT_WRAPPER_COMMAND,
+		"nix",
+		"rs",
+		"--systemd-run",
+		"--systemd-unit",
+		unitName,
+		"--flake-dir",
+		stagedFlakeDir,
+		// Activation reads the staged flake after dogeboxd may have been
+		// stopped, so cleanup must happen inside _dbxroot's transient unit.
+		"--cleanup-flake-dir",
+		"--set-release",
+		updateVersion,
+	}
+}
+
+func stageReleaseFlake(tmpDir, updateVersion string, logger dogeboxd.SubLogger) (string, string, error) {
 	return stageReleaseFlakeWithClone(tmpDir, updateVersion, logger, cloneReleaseRepository)
 }
 
-func stageReleaseFlakeWithClone(tmpDir, updateVersion string, logger dogeboxd.SubLogger, cloneFunc func(string, string) error) (string, error) {
+func stageReleaseFlakeWithClone(tmpDir, updateVersion string, logger dogeboxd.SubLogger, cloneFunc func(string, string) error) (string, string, error) {
 	if tmpDir == "" {
 		tmpDir = os.TempDir()
 	}
 
 	cloneDir, err := os.MkdirTemp(tmpDir, "os-upgrade-*")
 	if err != nil {
-		return "", fmt.Errorf("failed to create temp dir for OS release %s: %w", updateVersion, err)
+		return "", "", fmt.Errorf("failed to create temp dir for OS release %s: %w", updateVersion, err)
 	}
 
 	if logger != nil {
@@ -199,33 +242,38 @@ func stageReleaseFlakeWithClone(tmpDir, updateVersion string, logger dogeboxd.Su
 
 	if err := cloneFunc(cloneDir, updateVersion); err != nil {
 		_ = os.RemoveAll(cloneDir)
-		return "", err
+		return "", "", err
 	}
 
 	flakePath := filepath.Join(cloneDir, "flake.nix")
 	if _, err := os.Stat(flakePath); err != nil {
 		_ = os.RemoveAll(cloneDir)
-		return "", fmt.Errorf("staged OS release %s is missing flake.nix: %w", updateVersion, err)
+		return "", "", fmt.Errorf("staged OS release %s is missing flake.nix: %w", updateVersion, err)
 	}
 
 	commitHash, err := getRepositoryHeadHash(cloneDir)
 	if err != nil {
 		_ = os.RemoveAll(cloneDir)
-		return "", err
+		return "", "", err
+	}
+
+	if err := os.RemoveAll(filepath.Join(cloneDir, ".git")); err != nil {
+		_ = os.RemoveAll(cloneDir)
+		return "", "", fmt.Errorf("failed to strip Git metadata from staged OS release: %w", err)
 	}
 
 	finalDir := buildStagedReleaseDirPath(tmpDir, updateVersion, commitHash)
 	if err := os.RemoveAll(finalDir); err != nil {
 		_ = os.RemoveAll(cloneDir)
-		return "", fmt.Errorf("failed to clear existing staged OS release dir %s: %w", finalDir, err)
+		return "", "", fmt.Errorf("failed to clear existing staged OS release dir %s: %w", finalDir, err)
 	}
 
 	if err := os.Rename(cloneDir, finalDir); err != nil {
 		_ = os.RemoveAll(cloneDir)
-		return "", fmt.Errorf("failed to move staged OS release into %s: %w", finalDir, err)
+		return "", "", fmt.Errorf("failed to move staged OS release into %s: %w", finalDir, err)
 	}
 
-	return finalDir, nil
+	return finalDir, commitHash, nil
 }
 
 func doSystemUpdate(pkg string, updateVersion string, tmpDir string, logger dogeboxd.SubLogger) error {
@@ -262,17 +310,12 @@ func doSystemUpdateWithDependencies(
 		return UpdateVersionUnavailableError{Package: pkg, Version: updateVersion}
 	}
 
-	stagedFlakeDir, err := stageReleaseFlakeWithClone(tmpDir, updateVersion, logger, cloneFunc)
+	stagedFlakeDir, commitHash, err := stageReleaseFlakeWithClone(tmpDir, updateVersion, logger, cloneFunc)
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if err := os.RemoveAll(stagedFlakeDir); err != nil && logger != nil {
-			logger.Errf("Failed to clean up staged flake %s: %v", stagedFlakeDir, err)
-		}
-	}()
 
-	cmd := execCommand(SUDO_COMMAND, "_dbxroot", "nix", "rs", "--flake-dir", stagedFlakeDir, "--set-release", updateVersion)
+	cmd := execCommand(SUDO_COMMAND, buildSystemUpdateCommandArgs(stagedFlakeDir, updateVersion, buildSystemUpdateUnitName(updateVersion, commitHash))...)
 	if logger != nil {
 		logger.Logf("Running command: %s %s", cmd.Path, strings.Join(cmd.Args[1:], " "))
 		cmd.Stdout = io.MultiWriter(os.Stdout, dogeboxd.NewLineWriter(func(s string) {

--- a/pkg/system/upgrades_test.go
+++ b/pkg/system/upgrades_test.go
@@ -422,19 +422,23 @@ func TestStageReleaseFlakeCreatesCloneInConfiguredTempDir(t *testing.T) {
 		return createTestReleaseRepo(t, destination, version)
 	}
 
-	stagedPath, err := stageReleaseFlakeWithClone(tmpDir, "v1.2.3", nil, cloneFunc)
+	stagedPath, commitHash, err := stageReleaseFlakeWithClone(tmpDir, "v1.2.3", nil, cloneFunc)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
 	headHash, err := getRepositoryHeadHash(stagedPath)
-	if err != nil {
-		t.Fatalf("expected staged repository hash, got %v", err)
+	if err == nil {
+		t.Fatalf("expected staged release to be a plain path, got readable Git hash %s", headHash)
 	}
 
-	expectedPath := buildStagedReleaseDirPath(tmpDir, "v1.2.3", headHash)
+	expectedCommitHash := stagedCommitHash(t, cloneFunc, "v1.2.3")
+	expectedPath := buildStagedReleaseDirPath(tmpDir, "v1.2.3", expectedCommitHash)
 	if stagedPath != expectedPath {
 		t.Fatalf("expected staged path %q, got %q", expectedPath, stagedPath)
+	}
+	if commitHash != expectedCommitHash {
+		t.Fatalf("expected commit hash %q, got %q", expectedCommitHash, commitHash)
 	}
 
 	if _, err := os.Stat(filepath.Join(stagedPath, "flake.nix")); err != nil {
@@ -448,7 +452,7 @@ func TestStageReleaseFlakeReplacesExistingHashNamedDir(t *testing.T) {
 		return createTestReleaseRepo(t, destination, version)
 	}
 
-	firstStagedPath, err := stageReleaseFlakeWithClone(tmpDir, "v1.2.3", nil, cloneFunc)
+	firstStagedPath, _, err := stageReleaseFlakeWithClone(tmpDir, "v1.2.3", nil, cloneFunc)
 	if err != nil {
 		t.Fatalf("expected first staging run to succeed, got %v", err)
 	}
@@ -458,7 +462,7 @@ func TestStageReleaseFlakeReplacesExistingHashNamedDir(t *testing.T) {
 		t.Fatalf("failed to create sentinel file: %v", err)
 	}
 
-	stagedPath, err := stageReleaseFlakeWithClone(tmpDir, "v1.2.3", nil, cloneFunc)
+	stagedPath, _, err := stageReleaseFlakeWithClone(tmpDir, "v1.2.3", nil, cloneFunc)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -528,7 +532,19 @@ func TestSystemUpdaterDoSystemUpdateUsesStagedFlakeDir(t *testing.T) {
 		t.Fatalf("expected command %q, got %q", SUDO_COMMAND, capturedName)
 	}
 
-	expectedArgs := []string{"_dbxroot", "nix", "rs", "--flake-dir", stagedPath, "--set-release", "v1.2.0"}
+	expectedArgs := []string{
+		DBXROOT_WRAPPER_COMMAND,
+		"nix",
+		"rs",
+		"--systemd-run",
+		"--systemd-unit",
+		buildSystemUpdateUnitName("v1.2.0", stagedCommitHash(t, cloneFunc, "v1.2.0")),
+		"--flake-dir",
+		stagedPath,
+		"--cleanup-flake-dir",
+		"--set-release",
+		"v1.2.0",
+	}
 	if len(capturedArgs) != len(expectedArgs) {
 		t.Fatalf("expected args %v, got %v", expectedArgs, capturedArgs)
 	}
@@ -538,8 +554,8 @@ func TestSystemUpdaterDoSystemUpdateUsesStagedFlakeDir(t *testing.T) {
 		}
 	}
 
-	if _, err := os.Stat(stagedPath); !os.IsNotExist(err) {
-		t.Fatalf("expected staged flake dir %q to be cleaned up, stat err: %v", stagedPath, err)
+	if _, err := os.Stat(stagedPath); err != nil {
+		t.Fatalf("expected staged flake dir %q to remain available for transient unit cleanup, stat err: %v", stagedPath, err)
 	}
 }
 
@@ -578,6 +594,22 @@ func createTestReleaseRepo(t *testing.T, destination string, version string) err
 		},
 	})
 	return err
+}
+
+func stagedCommitHash(t *testing.T, cloneFunc func(string, string) error, version string) string {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	if err := cloneFunc(tmpDir, version); err != nil {
+		t.Fatalf("failed to create test release repo: %v", err)
+	}
+
+	hash, err := getRepositoryHeadHash(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to read test release hash: %v", err)
+	}
+
+	return hash
 }
 
 /* TODO : check if versioning file(s) were written out


### PR DESCRIPTION
This fixes the `0.8.x` to `0.9.x` migration by allowing dogeboxd to recover from partially completed OS activations, keeping the staged OS flake available until activation finishes.

The main issue previously, was that dogeboxd would be stopped halfway through `nixos-rebuild switch` because the new system restarted `dogeboxd.service` during activation. This would cause the migration process to be killed before it could finish copying the new OS flake into `/etc/nixos `and updating the version files.

### Testing notes

A custom `0.8.1` image needs to be used as the base, allowing pre-release software updates to be enabled in the dev menu.

The following `migrations.json` file also needs to be created, so the migrator also allows pre-release software updates
```
sudo mkdir -p /opt/dogebox && sudo tee /opt/dogebox/migrations.json >/dev/null <<'EOF'
{
  "pre_0.9_os_flake": {
    "doNotRun": false,
    "config": {
      "includePreReleases": true
    }
  }
}
EOF

sudo chown dogeboxd:dogebox /opt/dogebox/migrations.json

sudo chmod 0640 /opt/dogebox/migrations.json

sudo systemctl restart dogeboxd
```

### New features

* Runs OS rebuilds through a `_dbxroot` systemd unit, so activation can survive dogeboxd restarts.
* Detects stale `/etc/nixos/flake.nix` state after a partial upgrade and re-runs the current OS release to finish landing the new flake.
* Records migration completion only after the installed OS flake and current DBX release both satisfy the target state.
* Replaces the previous `runs` based tracking for migrations, replaces with simpler `ranSuccessfully` which is set after a successful run. This complements `doNotRun` which can be set by the os to stop the migration being run at all.
* Tidy system update jobs after restart so they're not left in a confusing failed state. A log note is added for the expected interruption: `System update was interrupted by dogeboxd restart. This is expected when performing a 0.8.x to 0.9.x update; restart dogeboxd to continue phase 2.`.

### Required os PR
https://github.com/Dogebox-WG/os/pull/88