### PR TITLE
Fix/pup dependency resolution

### DIFF
--- a/pkg/web/pups.go
+++ b/pkg/web/pups.go
@@ -85,6 +85,95 @@ type InstallPupRequest struct {
 	EnableDevMode           bool `json:"installWithDevModeEnabled"`
 }
 
+func installKey(sourceID, pupName, pupVersion string) string {
+	return fmt.Sprintf("%s:%s:%s", sourceID, pupName, pupVersion)
+}
+
+func hasPreferredSource(source dogeboxd.PupManifestDependencySource) bool {
+	return source.SourceLocation != "" || source.PupName != "" || source.PupVersion != ""
+}
+
+func matchesPreferredSource(candidate, preferred dogeboxd.PupManifestDependencySource) bool {
+	if preferred.SourceLocation != "" && candidate.SourceLocation != preferred.SourceLocation {
+		return false
+	}
+	if preferred.PupName != "" && candidate.PupName != preferred.PupName {
+		return false
+	}
+	if preferred.PupVersion != "" && candidate.PupVersion != preferred.PupVersion {
+		return false
+	}
+	return hasPreferredSource(preferred)
+}
+
+func pickDependencySource(dep dogeboxd.PupDependencyReport) (dogeboxd.PupManifestDependencySource, bool) {
+	if dep.CurrentProvider != "" || len(dep.InstalledProviders) > 0 {
+		return dogeboxd.PupManifestDependencySource{}, false
+	}
+
+	if len(dep.InstallableProviders) == 0 {
+		return dogeboxd.PupManifestDependencySource{}, false
+	}
+
+	if hasPreferredSource(dep.DefaultSourceProvider) {
+		for _, source := range dep.InstallableProviders {
+			if matchesPreferredSource(source, dep.DefaultSourceProvider) {
+				return source, true
+			}
+		}
+	}
+
+	return dep.InstallableProviders[0], true
+}
+
+func resolveSourceID(sourceLists map[string]dogeboxd.ManifestSourceList, sourceLocation string) (string, error) {
+	for sourceID, sourceList := range sourceLists {
+		if sourceList.Config.Location == sourceLocation {
+			return sourceID, nil
+		}
+	}
+
+	return "", fmt.Errorf("no source found for location %q", sourceLocation)
+}
+
+func buildDependencyInstallRequests(
+	deps []dogeboxd.PupDependencyReport,
+	sourceLists map[string]dogeboxd.ManifestSourceList,
+	sessionToken string,
+	seenInstalls map[string]struct{},
+) ([]dogeboxd.InstallPup, error) {
+	installs := make([]dogeboxd.InstallPup, 0)
+
+	for _, dep := range deps {
+		source, ok := pickDependencySource(dep)
+		if !ok {
+			continue
+		}
+
+		sourceID, err := resolveSourceID(sourceLists, source.SourceLocation)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't resolve source for dependency %q: %w", dep.Interface, err)
+		}
+
+		key := installKey(sourceID, source.PupName, source.PupVersion)
+		if seenInstalls != nil {
+			if _, exists := seenInstalls[key]; exists {
+				continue
+			}
+			seenInstalls[key] = struct{}{}
+		}
+
+		installs = append(installs, dogeboxd.InstallPup{
+			PupName:      source.PupName,
+			PupVersion:   source.PupVersion,
+			SourceId:     sourceID,
+			SessionToken: sessionToken,
+		})
+	}
+
+	return installs, nil
+}
+
 // calculateDependencies creates a temporary pup state and calculates its dependencies
 func (t api) calculateDependencies(sourceId, pupName, pupVersion string) (*dogeboxd.PupState, []dogeboxd.PupDependencyReport, error) {
 	// Create a temporary pup - this will be used to calculate dependencies
@@ -139,6 +228,18 @@ func (t api) installPup(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		allSources, err := t.sources.GetAll(false)
+		if err != nil {
+			sendErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		dependencyInstalls, err := buildDependencyInstallRequests(deps, allSources, req.SessionToken, map[string]struct{}{})
+		if err != nil {
+			sendErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
 		// Add the batch installation action
 		id := t.dbx.AddAction(dogeboxd.InstallPup{
 			PupName:    req.PupName,
@@ -151,20 +252,8 @@ func (t api) installPup(w http.ResponseWriter, r *http.Request) {
 		})
 
 		// Add installation actions for dependencies
-		for _, dep := range deps {
-			if dep.CurrentProvider == "" {
-				// Use the first available provider for each dependency
-				if len(dep.InstallableProviders) > 0 {
-					provider := dep.InstallableProviders[0]
-					// Use the same source ID as the main pup for dependencies
-					t.dbx.AddAction(dogeboxd.InstallPup{
-						PupName:      provider.PupName,
-						PupVersion:   provider.PupVersion,
-						SourceId:     req.SourceId, // Use the same source ID as the main pup
-						SessionToken: req.SessionToken,
-					})
-				}
-			}
+		for _, install := range dependencyInstalls {
+			t.dbx.AddAction(install)
 		}
 
 		sendResponse(w, map[string]string{"id": id})
@@ -285,6 +374,12 @@ func (t api) installPups(w http.ResponseWriter, r *http.Request) {
 
 	// Create batch installation requests
 	installRequests := make([]dogeboxd.InstallPup, 0)
+	seenDependencyInstalls := map[string]struct{}{}
+	allSources, err := t.sources.GetAll(false)
+	if err != nil {
+		sendErrorResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
 	// Process each pup and its dependencies if auto-install is enabled
 	for _, pup := range req.Pups {
@@ -306,23 +401,12 @@ func (t api) installPups(w http.ResponseWriter, r *http.Request) {
 				SessionToken: pup.SessionToken,
 			})
 
-			// Add all required dependencies
-			for _, dep := range deps {
-				if dep.CurrentProvider == "" {
-					// Use the first available provider for each dependency
-					if len(dep.InstallableProviders) > 0 {
-						provider := dep.InstallableProviders[0]
-						// Use the same source ID as the main pup for dependencies
-						installRequests = append(installRequests, dogeboxd.InstallPup{
-							PupName:      provider.PupName,
-							PupVersion:   provider.PupVersion,
-							SourceId:     pup.SourceId, // Use same source for dependencies
-							Options:      dogeboxd.AdoptPupOptions{},
-							SessionToken: pup.SessionToken,
-						})
-					}
-				}
+			dependencyInstalls, err := buildDependencyInstallRequests(deps, allSources, pup.SessionToken, seenDependencyInstalls)
+			if err != nil {
+				sendErrorResponse(w, http.StatusBadRequest, err.Error())
+				return
 			}
+			installRequests = append(installRequests, dependencyInstalls...)
 		} else {
 			// Add just the main pup if auto-install is disabled
 			installRequests = append(installRequests, dogeboxd.InstallPup{

--- a/pkg/web/pups_test.go
+++ b/pkg/web/pups_test.go
@@ -1,0 +1,163 @@
+package web
+
+import (
+	"testing"
+
+	dogeboxd "github.com/Dogebox-WG/dogeboxd/pkg"
+)
+
+func TestPickDependencySourceSkipsCurrentProvider(t *testing.T) {
+	dep := dogeboxd.PupDependencyReport{
+		Interface:       "core-rpc",
+		CurrentProvider: "existing-provider",
+		InstallableProviders: []dogeboxd.PupManifestDependencySource{
+			{SourceLocation: "https://example.com/source-a.git", PupName: "Dogecoin Core Remote", PupVersion: "2.0.0"},
+		},
+	}
+
+	_, ok := pickDependencySource(dep)
+	if ok {
+		t.Fatal("expected no source to be selected when a current provider is already set")
+	}
+}
+
+func TestPickDependencySourceSkipsInstalledProvider(t *testing.T) {
+	dep := dogeboxd.PupDependencyReport{
+		Interface:          "core-zmq",
+		InstalledProviders: []string{"dogecoin-core"},
+		InstallableProviders: []dogeboxd.PupManifestDependencySource{
+			{SourceLocation: "https://example.com/source-a.git", PupName: "Dogecoin Core Remote", PupVersion: "2.0.0"},
+		},
+	}
+
+	_, ok := pickDependencySource(dep)
+	if ok {
+		t.Fatal("expected no source to be selected when a compatible provider is already installed")
+	}
+}
+
+func TestBuildDependencyInstallRequestsPrefersDefaultSource(t *testing.T) {
+	sourceLists := map[string]dogeboxd.ManifestSourceList{
+		"dogecoin-core": {
+			Config: dogeboxd.ManifestSourceConfiguration{
+				ID:       "dogecoin-core",
+				Location: "https://example.com/source-a.git",
+			},
+		},
+		"dogecoin-remote": {
+			Config: dogeboxd.ManifestSourceConfiguration{
+				ID:       "dogecoin-remote",
+				Location: "https://example.com/source-b.git",
+			},
+		},
+	}
+
+	deps := []dogeboxd.PupDependencyReport{
+		{
+			Interface: "core-rpc",
+			InstallableProviders: []dogeboxd.PupManifestDependencySource{
+				{SourceLocation: "https://example.com/source-b.git", PupName: "Dogecoin Core Remote", PupVersion: "2.0.0"},
+				{SourceLocation: "https://example.com/source-a.git", PupName: "Dogecoin Core", PupVersion: "1.14.7"},
+			},
+			DefaultSourceProvider: dogeboxd.PupManifestDependencySource{
+				SourceLocation: "https://example.com/source-a.git",
+				PupName:        "Dogecoin Core",
+				PupVersion:     "1.14.7",
+			},
+		},
+	}
+
+	installs, err := buildDependencyInstallRequests(deps, sourceLists, "session-token", map[string]struct{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(installs) != 1 {
+		t.Fatalf("expected one dependency install, got %d", len(installs))
+	}
+
+	install := installs[0]
+	if install.SourceId != "dogecoin-core" {
+		t.Fatalf("expected dependency source ID to come from the selected source, got %q", install.SourceId)
+	}
+	if install.PupName != "Dogecoin Core" || install.PupVersion != "1.14.7" {
+		t.Fatalf("expected default source to be selected, got %s %s", install.PupName, install.PupVersion)
+	}
+}
+
+func TestBuildDependencyInstallRequestsFallsBackToFirstInstallableSource(t *testing.T) {
+	sourceLists := map[string]dogeboxd.ManifestSourceList{
+		"remote-source": {
+			Config: dogeboxd.ManifestSourceConfiguration{
+				ID:       "remote-source",
+				Location: "https://example.com/source-b.git",
+			},
+		},
+	}
+
+	deps := []dogeboxd.PupDependencyReport{
+		{
+			Interface: "core-rpc",
+			InstallableProviders: []dogeboxd.PupManifestDependencySource{
+				{SourceLocation: "https://example.com/source-b.git", PupName: "Dogecoin Core Remote", PupVersion: "2.0.0"},
+				{SourceLocation: "https://example.com/source-b.git", PupName: "Dogecoin Core Remote", PupVersion: "1.9.0"},
+			},
+			DefaultSourceProvider: dogeboxd.PupManifestDependencySource{
+				SourceLocation: "https://example.com/source-a.git",
+				PupName:        "Dogecoin Core",
+				PupVersion:     "1.14.7",
+			},
+		},
+	}
+
+	installs, err := buildDependencyInstallRequests(deps, sourceLists, "session-token", map[string]struct{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(installs) != 1 {
+		t.Fatalf("expected one dependency install, got %d", len(installs))
+	}
+
+	install := installs[0]
+	if install.PupName != "Dogecoin Core Remote" || install.PupVersion != "2.0.0" {
+		t.Fatalf("expected the first installable source to be selected, got %s %s", install.PupName, install.PupVersion)
+	}
+}
+
+func TestBuildDependencyInstallRequestsDeduplicatesSources(t *testing.T) {
+	sourceLists := map[string]dogeboxd.ManifestSourceList{
+		"shared-source": {
+			Config: dogeboxd.ManifestSourceConfiguration{
+				ID:       "shared-source",
+				Location: "https://example.com/source-a.git",
+			},
+		},
+	}
+
+	source := dogeboxd.PupManifestDependencySource{
+		SourceLocation: "https://example.com/source-a.git",
+		PupName:        "Dogecoin Core",
+		PupVersion:     "1.14.7",
+	}
+
+	deps := []dogeboxd.PupDependencyReport{
+		{
+			Interface:            "core-rpc",
+			InstallableProviders: []dogeboxd.PupManifestDependencySource{source},
+		},
+		{
+			Interface:            "core-zmq",
+			InstallableProviders: []dogeboxd.PupManifestDependencySource{source},
+		},
+	}
+
+	installs, err := buildDependencyInstallRequests(deps, sourceLists, "session-token", map[string]struct{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(installs) != 1 {
+		t.Fatalf("expected duplicate source installs to be collapsed, got %d installs", len(installs))
+	}
+	if installs[0].SessionToken != "session-token" {
+		t.Fatalf("expected session token to be preserved, got %q", installs[0].SessionToken)
+	}
+}


### PR DESCRIPTION
Installing a pup with automatic dependency resolution now considers providers that are already installed, preventing dogeboxd from installing in a second pup unnecessarily.
When a dependency does need to be installed, Dogebox now prefers the manifest's default source and avoids scheduling the same dependency install more than once.

### New features

* Skip auto-installing a second dependency provider when a compatible pup is already installed
* Prefer the manifest's default dependency source before falling back to other installable sources
* Use the selected dependency source when auto-installing a missing provider, and avoid queueing the same dependency install twice
