### PR TITLE
GitHub PAT support for dogeboxd commands

### DIFF
--- a/cmd/_dbxroot/cmd/nix-rb.go
+++ b/cmd/_dbxroot/cmd/nix-rb.go
@@ -10,12 +10,13 @@ import (
 
 var nixRBSetRelease string
 var nixRBFlakeDir string
+var nixRBGitHubToken string
 
 var rbCmd = &cobra.Command{
 	Use:   "rb",
 	Short: "Executes nixos-rebuild boot",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := utils.RunNixOSRebuild("boot", nixRBSetRelease, nixRBFlakeDir); err != nil {
+		if err := utils.RunNixOSRebuild("boot", nixRBSetRelease, nixRBFlakeDir, nixRBGitHubToken); err != nil {
 			fmt.Fprintf(os.Stderr, "Error executing nixos-rebuild boot: %v\n", err)
 			os.Exit(1)
 		}
@@ -25,5 +26,6 @@ var rbCmd = &cobra.Command{
 func init() {
 	rbCmd.Flags().StringVarP(&nixRBSetRelease, "set-release", "s", "", "rebuild with specific release (used for upgrades)")
 	rbCmd.Flags().StringVar(&nixRBFlakeDir, "flake-dir", "", "rebuild from a specific flake directory")
+	rbCmd.Flags().StringVar(&nixRBGitHubToken, "github-token", "", "GitHub token (use for more API request allocation)")
 	nixCmd.AddCommand(rbCmd)
 }

--- a/cmd/_dbxroot/cmd/nix-rs.go
+++ b/cmd/_dbxroot/cmd/nix-rs.go
@@ -11,6 +11,7 @@ import (
 
 var nixRSSetRelease string
 var nixRSFlakeDir string
+var nixRSGitHubToken string
 var nixRSSystemdRun bool
 var nixRSSystemdUnit string
 var nixRSCleanupFlakeDir bool
@@ -73,7 +74,7 @@ var rsCmd = &cobra.Command{
 			return
 		}
 
-		if err := utils.RunNixOSRebuild("switch", nixRSSetRelease, nixRSFlakeDir); err != nil {
+		if err := utils.RunNixOSRebuild("switch", nixRSSetRelease, nixRSFlakeDir, nixRSGitHubToken); err != nil {
 			fmt.Fprintf(os.Stderr, "Error executing nixos-rebuild switch: %v\n", err)
 			os.Exit(1)
 		}
@@ -99,5 +100,6 @@ func init() {
 	rsCmd.Flags().BoolVar(&nixRSSystemdRun, "systemd-run", false, "run rebuild inside a transient systemd unit")
 	rsCmd.Flags().StringVar(&nixRSSystemdUnit, "systemd-unit", "", "transient systemd unit name")
 	rsCmd.Flags().BoolVar(&nixRSCleanupFlakeDir, "cleanup-flake-dir", false, "remove the flake directory after a successful rebuild")
+	rsCmd.Flags().StringVar(&nixRSGitHubToken, "github-token", "", "GitHub token (use for more API request allocation)")
 	nixCmd.AddCommand(rsCmd)
 }

--- a/cmd/_dbxroot/utils/nix-rebuild.go
+++ b/cmd/_dbxroot/utils/nix-rebuild.go
@@ -3,9 +3,10 @@ package utils
 import (
 	"os"
 	"os/exec"
+	"strings"
 )
 
-func RunNixOSRebuild(action string, setRelease string, flakeDir string) error {
+func RunNixOSRebuild(action string, setRelease string, flakeDir string, githubToken string) error {
 	rebuildCommand, rebuildArgs, err := GetRebuildCommand(action, setRelease, flakeDir)
 	if err != nil {
 		return err
@@ -15,8 +16,26 @@ func RunNixOSRebuild(action string, setRelease string, flakeDir string) error {
 	execCmd.Stdout = os.Stdout
 	execCmd.Stderr = os.Stderr
 
+	env := os.Environ()
+	var extraEnv []string
+
+	if githubToken != "" {
+		nixConfig := strings.TrimSpace(os.Getenv("NIX_CONFIG"))
+		accessTokenLine := "access-tokens = github.com=" + githubToken
+		if nixConfig == "" {
+			nixConfig = accessTokenLine
+		} else if !strings.Contains(nixConfig, "github.com=") {
+			nixConfig = nixConfig + "\n" + accessTokenLine
+		}
+		extraEnv = append(extraEnv, "NIX_CONFIG="+nixConfig)
+	}
+
 	if flakeDir != "" {
-		execCmd.Env = append(os.Environ(), "DBX_UPGRADE_FLAKE_DIR="+flakeDir)
+		extraEnv = append(extraEnv, "DBX_UPGRADE_FLAKE_DIR="+flakeDir)
+	}
+
+	if len(extraEnv) > 0 {
+		execCmd.Env = append(env, extraEnv...)
 	}
 
 	return execCmd.Run()

--- a/pkg/system/upgrades.go
+++ b/pkg/system/upgrades.go
@@ -205,7 +205,7 @@ func buildSystemUpdateUnitName(updateVersion string, commitHash string) string {
 }
 
 func buildSystemUpdateCommandArgs(stagedFlakeDir string, updateVersion string, unitName string) []string {
-	return []string{
+	args := []string{
 		DBXROOT_WRAPPER_COMMAND,
 		"nix",
 		"rs",
@@ -220,6 +220,10 @@ func buildSystemUpdateCommandArgs(stagedFlakeDir string, updateVersion string, u
 		"--set-release",
 		updateVersion,
 	}
+	if token := strings.TrimSpace(os.Getenv("GITHUB_TOKEN")); token != "" {
+		args = append(args, "--github-token", token)
+	}
+	return args
 }
 
 func stageReleaseFlake(tmpDir, updateVersion string, logger dogeboxd.SubLogger) (string, string, error) {

--- a/pkg/system/upgrades.go
+++ b/pkg/system/upgrades.go
@@ -226,6 +226,17 @@ func buildSystemUpdateCommandArgs(stagedFlakeDir string, updateVersion string, u
 	return args
 }
 
+func redactGitHubTokenInArgs(args []string) []string {
+	out := make([]string, len(args))
+	copy(out, args)
+	for i := 0; i < len(out)-1; i++ {
+		if out[i] == "--github-token" {
+			out[i+1] = "[REDACTED]"
+		}
+	}
+	return out
+}
+
 func stageReleaseFlake(tmpDir, updateVersion string, logger dogeboxd.SubLogger) (string, string, error) {
 	return stageReleaseFlakeWithClone(tmpDir, updateVersion, logger, cloneReleaseRepository)
 }
@@ -321,7 +332,7 @@ func doSystemUpdateWithDependencies(
 
 	cmd := execCommand(SUDO_COMMAND, buildSystemUpdateCommandArgs(stagedFlakeDir, updateVersion, buildSystemUpdateUnitName(updateVersion, commitHash))...)
 	if logger != nil {
-		logger.Logf("Running command: %s %s", cmd.Path, strings.Join(cmd.Args[1:], " "))
+		logger.Logf("Running command: %s %s", cmd.Path, strings.Join(redactGitHubTokenInArgs(cmd.Args[1:]), " "))
 		cmd.Stdout = io.MultiWriter(os.Stdout, dogeboxd.NewLineWriter(func(s string) {
 			logger.Log(s)
 		}))

--- a/pkg/system/upgrades_test.go
+++ b/pkg/system/upgrades_test.go
@@ -24,6 +24,46 @@ func (m *MockRepoTagsFetcher) GetRepoTags(repo string) ([]RepositoryTag, error) 
 	return m.tags, m.err
 }
 
+func TestRedactGitHubTokenInArgs(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "no token flag",
+			in:   []string{"sudo", "_dbxroot", "nix", "rs", "--flake-dir", "/tmp/x"},
+			want: []string{"sudo", "_dbxroot", "nix", "rs", "--flake-dir", "/tmp/x"},
+		},
+		{
+			name: "github token redacted",
+			in:   []string{"sudo", "_dbxroot", "nix", "rs", "--github-token", "ghp_secret"},
+			want: []string{"sudo", "_dbxroot", "nix", "rs", "--github-token", "[REDACTED]"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := redactGitHubTokenInArgs(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len got %d want %d", len(got), len(tc.want))
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("index %d: got %q want %q", i, got[i], tc.want[i])
+				}
+			}
+			// Original slice must be unchanged (copy semantics).
+			if len(tc.in) >= 2 && tc.in[len(tc.in)-1] == "ghp_secret" {
+				if tc.in[len(tc.in)-1] != "ghp_secret" {
+					t.Error("input slice was mutated")
+				}
+			}
+		})
+	}
+}
+
 // TODO : this only tests the semver module
 func TestSemverValidation(t *testing.T) {
 	testCases := []struct {

--- a/pkg/web/custom.nix.default
+++ b/pkg/web/custom.nix.default
@@ -4,6 +4,11 @@
   # Custom NixOS Configuration
   # Add your custom NixOS modules and configuration here.
   # This file is included in the system configuration when it exists.
+
+  # Specifying a GitHub Personal Access Token, may be needed if there
+  # are a lot of GitHub API requests from your network.
+  #
+  # systemd.services.dogeboxd.environment.GITHUB_TOKEN = "TOKEN_GOES_HERE";
   
   # Example: Enable Tailscale VPN
   # 1. Uncomment the lines below

--- a/pkg/web/custom.nix.default
+++ b/pkg/web/custom.nix.default
@@ -5,11 +5,11 @@
   # Add your custom NixOS modules and configuration here.
   # This file is included in the system configuration when it exists.
 
-  # Specifying a GitHub Personal Access Token, may be needed if there
+  # Specifying a GitHub Personal Access Token.  May be needed if there
   # are a lot of GitHub API requests from your network.
   #
-  # systemd.services.dogeboxd.environment.GITHUB_TOKEN = "TOKEN_GOES_HERE";
-  
+  # systemd.services.dogeboxd.environment.GITHUB_TOKEN = "MY_PAT_HERE";
+
   # Example: Enable Tailscale VPN
   # 1. Uncomment the lines below
   # 2. Replace tskey-auth-XXXXX-XXXXXXXXXXXXXXXXX with your auth key from:


### PR DESCRIPTION
Adding support for GitHub PAT's to the '_dbxroot nix' commands.

Uses the GITHUB_TOKEN environment variable within dogeboxd so pup updates and other sections can continue using it, uses command line options in the _dbxroot commands so sudo can blow away the environment.