### PR TITLE
Refresh pup firewall

### DIFF
--- a/pkg/system/nix/nix.go
+++ b/pkg/system/nix/nix.go
@@ -139,10 +139,8 @@ func (nm nixManager) WritePupFile(
 		nm.UpdateFirewallRules(nixPatch, dbxState)
 	}
 
-	// If we need access to the internet, update the system container config.
-	if state.Manifest.Container.RequiresInternet {
-		nm.UpdateSystemContainerConfiguration(nixPatch)
-	}
+	// Update the system container regardless of pup requiring internet as 'offline' pups may still need to talk to other pups.
+	nm.UpdateSystemContainerConfiguration(nixPatch)
 
 	nixPatch.WritePupFile(state.ID, values)
 }


### PR DESCRIPTION
### Problem
When installing a pup for [Indexer](https://github.com/dogeorg/indexer), it couldn't connect to Core. Connection Refused.
Turned out to be because the pup had `RequiresInternet: false`, the system container would not be updated as part of the pup installation, and therefore the firewall rules would not be updated accordingly. 

### Solution
Update `nix.go` such that `nm.UpdateSystemContainerConfiguration` is always run, irrespective of `RequiresInternet`. This allows the firewall rules to be updated correctly