### PR TITLE
Correctly assign ports when a pup has more than one UI

### DIFF
--- a/pkg/pup/actions.go
+++ b/pkg/pup/actions.go
@@ -285,6 +285,7 @@ func (t PupManager) nextAvailablePorts(howMany int) []int {
 			_, exists := consumed[port]
 			if !exists && t.isPortAvailable(port) {
 				out = append(out, port)
+				consumed[port] = struct{}{}
 				fmt.Printf("Allocated port %d (available on system)\n", port)
 				break
 			}

--- a/pkg/pup/actions_test.go
+++ b/pkg/pup/actions_test.go
@@ -1,0 +1,15 @@
+package pup
+
+import "testing"
+
+func TestNextAvailablePortsReturnsUniquePortsInSingleAllocation(t *testing.T) {
+	manager := PupManager{}
+
+	ports := manager.nextAvailablePorts(2)
+	if len(ports) != 2 {
+		t.Fatalf("expected 2 ports, got %d", len(ports))
+	}
+	if ports[0] == ports[1] {
+		t.Fatalf("expected unique ports, got duplicate %d", ports[0])
+	}
+}


### PR DESCRIPTION
Tested a pup with two UIs, both were assigned the same port. After this change, they're assigned distinct ports