### PR TITLE
Serve nix-built dpanel from make dev command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,12 @@ default: build
 .PHONY: clean mkbuild build multipassdev dpanel-build dev recovery test dbxdev sync-api
 
 DPANEL_DIR ?= ../dpanel
-DPANEL_DIST ?= $(DPANEL_DIR)/dist
+# dpanel is built via its Nix package (the same derivation the OS image
+# ships), so npm never runs inside the shared checkout and the host's
+# node_modules (shared between macOS and the Linux VM under OrbStack) is
+# never clobbered with binaries for the wrong platform. The result symlink
+# points into the Nix store, where the package's $out is the dist directory.
+DPANEL_DIST ?= build/dpanel
 
 clean:
 	rm -rf ./build
@@ -31,32 +36,20 @@ build/_dbxroot: clean mkbuild
 multipassdev:
 	go run ./cmd/dogeboxd -v -addr 0.0.0.0 -pups ~/
 
-dpanel-build:
-	@set -eu; \
-	ROLLUP_OS=$$(uname -s | tr '[:upper:]' '[:lower:]'); \
-	ROLLUP_ARCH=$$(uname -m | sed 's/x86_64/x64/' | sed 's/aarch64/arm64/'); \
-	NEED_INSTALL=0; \
-	if [ ! -x "$(DPANEL_DIR)/node_modules/.bin/vite" ]; then \
-		NEED_INSTALL=1; \
-	elif ! ls "$(DPANEL_DIR)/node_modules/@rollup/rollup-$${ROLLUP_OS}-$${ROLLUP_ARCH}"* >/dev/null 2>&1; then \
-		echo "dpanel: node_modules built for wrong platform, reinstalling..."; \
-		NEED_INSTALL=1; \
-	fi; \
-	if command -v npm >/dev/null 2>&1; then \
-		if [ "$$NEED_INSTALL" = "1" ]; then \
-			npm --prefix "$(DPANEL_DIR)" ci; \
-		fi; \
-		npm --prefix "$(DPANEL_DIR)" run build; \
-	elif command -v nix >/dev/null 2>&1; then \
-		DPANEL_DIR="$(DPANEL_DIR)" NEED_INSTALL="$$NEED_INSTALL" nix shell nixpkgs#nodejs_22 --command sh -lc '\
-			cd "$$DPANEL_DIR" && \
-			if [ "$$NEED_INSTALL" = "1" ]; then npm ci; fi && \
-			npm run build \
-		'; \
-	else \
-		echo "error: missing npm (and nix). Install Node/npm or prebuild $(DPANEL_DIST)" >&2; \
+# Build dpanel with its own Nix package (the same one the OS image ships),
+# overriding the pinned dogeboxd source with this checkout so the generated
+# protos match the daemon being run. git+file refs build from the working
+# tree's *tracked* files: uncommitted edits are included, but brand-new files
+# must be `git add`ed before they appear in the build.
+dpanel-build: mkbuild
+	@command -v nix >/dev/null 2>&1 || { \
+		echo "error: nix is required to build dpanel (see $(DPANEL_DIR)/flake.nix)" >&2; \
 		exit 127; \
-	fi
+	}
+	nix build "git+file://$(realpath $(DPANEL_DIR))" \
+		--override-input dogeboxd-src "git+file://$(CURDIR)" \
+		--no-write-lock-file \
+		-o $(DPANEL_DIST)
 
 dev: build dpanel-build
 	/run/wrappers/bin/dogeboxd -v --addr 0.0.0.0 --danger-dev \

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,6 @@ default: build
 .PHONY: clean mkbuild build multipassdev dpanel-build dev recovery test dbxdev sync-api
 
 DPANEL_DIR ?= ../dpanel
-# dpanel is built via its Nix package (the same derivation the OS image
-# ships), so npm never runs inside the shared checkout and the host's
-# node_modules (shared between macOS and the Linux VM under OrbStack) is
-# never clobbered with binaries for the wrong platform. The result symlink
-# points into the Nix store, where the package's $out is the dist directory.
 DPANEL_DIST ?= build/dpanel
 
 clean:
@@ -36,20 +31,17 @@ build/_dbxroot: clean mkbuild
 multipassdev:
 	go run ./cmd/dogeboxd -v -addr 0.0.0.0 -pups ~/
 
-# Build dpanel with its own Nix package (the same one the OS image ships),
-# overriding the pinned dogeboxd source with this checkout so the generated
-# protos match the daemon being run. git+file refs build from the working
-# tree's *tracked* files: uncommitted edits are included, but brand-new files
-# must be `git add`ed before they appear in the build.
+# Build dpanel as the OS image does, using this checkout for matching protos.
+# Nix ignores untracked files, so stage new files before building.
 dpanel-build: mkbuild
 	@command -v nix >/dev/null 2>&1 || { \
 		echo "error: nix is required to build dpanel (see $(DPANEL_DIR)/flake.nix)" >&2; \
 		exit 127; \
 	}
-	nix build "git+file://$(realpath $(DPANEL_DIR))" \
+	nix build "git+file://$(abspath $(DPANEL_DIR))" \
 		--override-input dogeboxd-src "git+file://$(CURDIR)" \
 		--no-write-lock-file \
-		-o $(DPANEL_DIST)
+		-o "$(DPANEL_DIST)"
 
 dev: build dpanel-build
 	/run/wrappers/bin/dogeboxd -v --addr 0.0.0.0 --danger-dev \

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,10 @@ build/_dbxroot: clean mkbuild
 multipassdev:
 	go run ./cmd/dogeboxd -v -addr 0.0.0.0 -pups ~/
 
-# Build dpanel as the OS image does, using this checkout for matching protos.
-# Nix ignores untracked files, so stage new files before building.
+# Build dpanel with its Nix package, using this checkout for matching protos.
+# This avoids npm install clobbering shared node_modules with binaries for the
+# wrong platform.
+# Nix ignores untracked files, so stage new files first.
 dpanel-build: mkbuild
 	@command -v nix >/dev/null 2>&1 || { \
 		echo "error: nix is required to build dpanel (see $(DPANEL_DIR)/flake.nix)" >&2; \


### PR DESCRIPTION
On my local dev machine I noticed that after the TS migration, sometimes when setting up a fresh install I'd find that I'd hit issues with packages unexpectedly being found as installed for the wrong platform.
I suspected it was caused by `npm install` sometimes being run on the host machine and other times from within the orb/nix vm.

This changes dogeboxd’s `make dev` workflow to build dpanel through dpanel’s Nix package, rather than running npm directly in the shared dpanel checkout. This prevents OrbStack/Nix builds from replacing the host’s native npm dependencies. Nix is now required, and newly created source files must be staged before they are included in the build.